### PR TITLE
Changed mount type for production image and moved pgadmin pass to .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,5 @@
 POSTGRES_DB=badgehub
 POSTGRES_USER=badgehub
 POSTGRES_PASSWORD=badgehub
+PGADMIN_DEFAULT_PASSWORD=badgehub
+PGADMIN_DEFAULT_EMAIL=dev@badgehub.team

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -30,9 +30,6 @@ services:
       - PGADMIN_LISTEN_PORT=8082
       - PGADMIN_CONFIG_SERVER_MODE=False
       - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
-      - PGADMIN_DEFAULT_EMAIL=dev@badgehub.team
-      - PGADMIN_DEFAULT_PASSWORD=badgehub
     volumes:
       - /data/pgadmin:/var/lib/pgadmin
       - ./servers.json:/pgadmin4/servers.json
-

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -5,9 +5,9 @@ services:
     env_file:
       - .env
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - /data/postgres:/var/lib/postgresql/data
       - ./mockup-data.sql:/docker-entrypoint-initdb.d/data.sql
-      - ./backup:/var/backup
+      - /postgres_backup:/var/backup
 
   node:
     build: .
@@ -33,9 +33,6 @@ services:
       - PGADMIN_DEFAULT_EMAIL=dev@badgehub.team
       - PGADMIN_DEFAULT_PASSWORD=badgehub
     volumes:
-      - pgadmin_data:/var/lib/pgadmin
+      - /data/pgadmin:/var/lib/pgadmin
       - ./servers.json:/pgadmin4/servers.json
 
-volumes:
-  postgres_data:
-  pgadmin_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,8 +40,6 @@ services:
       - PGADMIN_LISTEN_PORT=8082
       - PGADMIN_CONFIG_SERVER_MODE=False
       - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
-      - PGADMIN_DEFAULT_EMAIL=dev@badgehub.team
-      - PGADMIN_DEFAULT_PASSWORD=badgehub
     volumes:
       - pgadmin_data:/var/lib/pgadmin
       - ./servers.json:/pgadmin4/servers.json


### PR DESCRIPTION
To not make too many separate PRs, I've merged this into one. Production docker compose file could set the data folders to be on the host itself to be made persistent apart from Docker itself. 

The other part is to add pgadmin credentials in the .env as for postgres. 