### PR TITLE
Added .env prod example and restored mounts to docker volumes

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,5 @@
+POSTGRES_DB=badgehub
+POSTGRES_USER=badgehub
+POSTGRES_PASSWORD=badgehub
+PGADMIN_DEFAULT_PASSWORD=badgehub
+PGADMIN_DEFAULT_EMAIL=dev@badgehub.team

--- a/docker-compose-production.yml
+++ b/docker-compose-production.yml
@@ -3,11 +3,11 @@ services:
     image: postgres:16
     restart: always
     env_file:
-      - .env
+      - .env.prod
     volumes:
-      - /data/postgres:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
       - ./mockup-data.sql:/docker-entrypoint-initdb.d/data.sql
-      - /postgres_backup:/var/backup
+      - ./backup:/var/backup
 
   node:
     build: .
@@ -25,11 +25,15 @@ services:
     ports:
       - "9002:8082"
     env_file:
-      - .env
+      - .env.prod
     environment:
       - PGADMIN_LISTEN_PORT=8082
       - PGADMIN_CONFIG_SERVER_MODE=False
       - PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False
     volumes:
-      - /data/pgadmin:/var/lib/pgadmin
+      - pgadmin_data:/var/lib/pgadmin
       - ./servers.json:/pgadmin4/servers.json
+
+volumes:
+  postgres_data:
+  pgadmin_data:


### PR DESCRIPTION
Hey,

I've changed the mounts back to the original way as this would be the preferred way of dealing with mounts and added the .prod env example. 