### PR TITLE
docker: revised docker image for production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,19 @@
+# Private keys can be in there
+**/.env
+**/personal-service-account.json
+
+# Dependencies
+**/node_modules
+
+# Useless and heavy folders
+**/build
+**/dist
+[...]
+**/.next
+**/.vercel
+**/.react-email
+
+# Other useless files in the image
+.git/
+.github/
+[...]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM node:22
+# Build Stage
+FROM node:22-bookworm-slim AS build
+
+WORKDIR /home/node/app
+
+COPY package*.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Prod stage
+FROM node:22-bookworm-slim
 
 WORKDIR /home/node/app
 ENV NODE_ENV=production
-EXPOSE 8081
 
-COPY process.json .
-COPY package*.json .
-# When available: COPY --exclude=*.map dist .
-COPY dist ./dist
-COPY public ./public
+# Copy only needed files
+COPY --from=build /home/node/app/dist ./dist
+COPY --from=build /home/node/app/public ./public
+COPY --from=build /home/node/app/package*.json ./
 
 RUN npm ci --only=production --ignore-scripts
 
+COPY process.json .
+USER node
+EXPOSE 8081
 CMD ["./node_modules/pm2/bin/pm2-runtime", "process.json"]
-


### PR DESCRIPTION
Hi,

Changed up the docker image, by my tests, the image should be 4-5x smaller, should be around 320MB instead of 1.3GB. With the current production docker compose it runs. 

Some changes:
- Node slim image
- Multi stage build
- Added .dockerignore to ignore any files getting accidentally in