### PR TITLE
Add startDevForDockerCompose.sh and use it in docker compose for auto npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,6 @@
 
 Make sure [Docker](https://www.docker.com/get-started/) is installed and running and Node.js and npm are installed.
 
-In the project directory, type
-
-```bash
-npm install
-```
-
-This will install `node_modules`.
-
 ## Run
 
 Before running, copy the `.env.example` into `.env`
@@ -30,33 +22,6 @@ Then start the Docker containers by typing
 
 ```bash
 docker compose up --detach
-```
-
-The first time Node.js might not start.
-
-```bash
-docker logs badgehub-api-node-1
-```
-
-If the logs say something like
-
-```text
-node:internal/modules/run_main:115
-    triggerUncaughtException(
-    ^
-Error [TransformError]:
-```
-
-Then node_modules have to be install from inside the container. type:
-
-```bash
-docker exec -it badgehub-api-node-1 npm install
-```
-
-and restart the service:
-
-```bash
-docker compose restart
 ```
 
 Then visit [http://localhost:8001/](http://localhost:8001/) for the development BadgeHub homepage.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ Or, to stop BadgeHub and delete all volumes (to start fresh)
 docker compose down --volumes
 ```
 
+### Applying commands to only 1 container from the compose file
+
+Container commands like `stop`, `start`, `restart` and `logs` can also be sent to one of the containers from the compose file. For example
+
+```bash
+docker compose restart node
+```
+
+will restart the node container only.
+
 ## Database schema
 
 At the moment, this is the database schema:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - .env
     environment:
       - NODE_ENV=development
-    command: "sh ./startDevFromDocker.sh"
+    command: "bash ./startDevForDockerCompose.sh"
     depends_on:
       - db
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - .env
     environment:
       - NODE_ENV=development
-    command: "npm run dev"
+    command: "sh ./startDevFromDocker.sh"
     depends_on:
       - db
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "node --import tsx --watch src/index.ts",
     "backup": "docker exec -it badgehub-api-db-1 /usr/bin/pg_dump --username badgehub badgehub -f /var/backup/data-backup-`date +\"%Y-%m-%dT%H:%m\"`.sql",
     "test": "vitest --coverage.enabled true",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "license": "MIT",
   "dependencies": {

--- a/startDevForDockerCompose.sh
+++ b/startDevForDockerCompose.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Check if node_modules directory exists
+if ! ls "node_modules" >/dev/null 2>&1; then
+  echo "node_modules not found. Running npm ci..."
+  npm ci --no-audit --no-fund
+else
+  if ! ls node_modules/@rollup/rollup-linux* >/dev/null 2>&1; then
+    echo "Warning! rollup does not seem to be installed correctly for docker, so we are reinstalling node_modules!"
+    npm ci --no-audit --no-fund
+  fi
+  echo "node_modules already exists. Skipping npm ci."
+fi
+
+npm run dev

--- a/startDevFromDocker.sh
+++ b/startDevFromDocker.sh
@@ -1,2 +1,0 @@
-npm i --no-fund --package-lock-only --no-audit &&\
-npm run dev

--- a/startDevFromDocker.sh
+++ b/startDevFromDocker.sh
@@ -1,0 +1,2 @@
+npm i --no-fund --package-lock-only --no-audit &&\
+npm run dev


### PR DESCRIPTION
This PR:
- Installs node modules from the node container upon startup.
- Updates the README to reflect that
- adds a little bit of extra documentation

It's a little bit of overhead, but
- if the node_modules are already installed, then this command only takes 1 second on an 8 year old i5 laptop, so seems fine.
- if the wrong node_modules are installed (eg if install was ran directly from a mac host), it will fix this.