### PR TITLE
Change DB_HOST to POSTGRES_HOST

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,6 @@ export const EXPRESS_PORT = 8081;
 export const POSTGRES_DB = process.env.POSTGRES_DB;
 export const POSTGRES_USER = process.env.POSTGRES_USER;
 export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD;
-export const POSTGRES_HOST = process.env.DB_HOST;
+export const POSTGRES_HOST = process.env.POSTGRES_HOST;
 export const POSTGRES_PORT = 5432;
 export const NODE_ENV = process.env.NODE_ENV;


### PR DESCRIPTION
Very small fix, but took me some time to figure out why the API stopped working. Better to be consistent and use POSTGRES_ for all Postgres env variables.

Make sure to set your `.env` file

POSTGRES_HOST= db


