### PR TITLE
Fix swagger express on production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "main": "src/index.ts",
   "scripts": {
     "install:container": "docker exec -it badgehub-api-node-1 npm install",
-    "start": "node dist/index.cjs",
+    "start": "node dist/index.mjs",
     "monitor": "docker exec -it badgehub-api-node-1 npx pm2 monit",
     "lint": "pretty-quick --check",
-    "build": "esbuild src/index.ts --bundle --platform=node --format=cjs --outfile=dist/index.cjs",
+    "build": "esbuild src/index.ts --bundle --platform=node --format=esm --packages=external --outfile=dist/index.mjs",
     "swagger": "tsoa spec-and-routes",
     "dev": "node --import tsx --watch src/index.ts",
     "test-db:up": "docker compose -f docker-compose.test-db.yml up -d",

--- a/process.json
+++ b/process.json
@@ -1,5 +1,5 @@
 {
-  "script": "dist/index.cjs",
+  "script": "dist/index.mjs",
   "interpreter": "node",
   "name": "badgehub",
   "exec_mode": "cluster",

--- a/src/db/sqlHelpers/dbDates.ts
+++ b/src/db/sqlHelpers/dbDates.ts
@@ -1,6 +1,6 @@
 import { DBDatedData } from "@db/models/app/DBDatedData";
 import { DatedData } from "@domain/readModels/app/DatedData";
-import moment from "moment/moment";
+import moment from "moment";
 
 export function extractDatedDataConverted(dbDatedData: DBDatedData): DatedData {
   const datedData: DatedData = {

--- a/src/db/sqlHelpers/projectQuery.ts
+++ b/src/db/sqlHelpers/projectQuery.ts
@@ -1,5 +1,5 @@
 import { Project } from "@domain/readModels/app/Project";
-import moment from "moment/moment";
+import moment from "moment";
 import { DBProject } from "@db/models/app/DBProject";
 import { DBVersion } from "@db/models/app/DBVersion";
 import { DBAppMetadataJSON as DBMetadataFileContents } from "@db/models/app/DBAppMetadataJSON";


### PR DESCRIPTION
Was not working because swagger-ui-express did not survive the bundling because not supported by esbuild. More info check here: https://github.com/evanw/esbuild/issues/2915#issuecomment-1428472519