### PR TITLE
feat(api): hide hidden apps

### DIFF
--- a/packages/backend/migrations/20250803151433-metadata-json-gin-index.js
+++ b/packages/backend/migrations/20250803151433-metadata-json-gin-index.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250803151433-metadata-json-gin-index-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20250803151433-metadata-json-gin-index-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/packages/backend/migrations/sqls/20250803151433-metadata-json-gin-index-down.sql
+++ b/packages/backend/migrations/sqls/20250803151433-metadata-json-gin-index-down.sql
@@ -1,0 +1,1 @@
+drop index if exists idx_v_app_metadata;

--- a/packages/backend/migrations/sqls/20250803151433-metadata-json-gin-index-up.sql
+++ b/packages/backend/migrations/sqls/20250803151433-metadata-json-gin-index-up.sql
@@ -1,0 +1,1 @@
+create index if not exists idx_v_app_metadata on versions using gin (app_metadata);

--- a/packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap
+++ b/packages/backend/src/__snapshots__/createSwaggerDoc.spec.ts.snap
@@ -372,6 +372,9 @@ exports[`createSwaggerDoc > swagger doc should match snapshot 1`] = `
                       "git": {
                         "type": "string",
                       },
+                      "hidden": {
+                        "type": "boolean",
+                      },
                       "icon_map": {
                         "description": "Icon Map of the project that maps from accepted sizes to a file path and url.",
                         "properties": {
@@ -2873,6 +2876,9 @@ This is an api key that can be used in the 'badgehub-api-token' header. Eg. set 
                       },
                       "git": {
                         "type": "string",
+                      },
+                      "hidden": {
+                        "type": "boolean",
                       },
                       "icon_map": {
                         "description": "Icon Map of the project that maps from accepted sizes to a file path and url.",

--- a/packages/backend/src/controllers/public-rest.spec.ts
+++ b/packages/backend/src/controllers/public-rest.spec.ts
@@ -33,39 +33,58 @@ describe(
       ).toBeDefined();
       expect(res.body.find((app: ProjectSummary) => app.slug === "codecraft"))
         .toMatchInlineSnapshot(`
-        {
-          "badges": [
-            "mch2022",
-            "why2025",
-          ],
-          "categories": [
-            "Event related",
-            "Games",
-          ],
-          "description": "With CodeCraft, you can do interesting things with the sensors.",
-          "git": null,
-          "icon_map": {
-            "64x64": {
-              "full_path": "icon5.png",
-              "url": "http://localhost:8081/api/v3/projects/codecraft/rev0/files/icon5.png",
+          {
+            "badges": [
+              "mch2022",
+              "why2025",
+            ],
+            "categories": [
+              "Event related",
+              "Games",
+            ],
+            "description": "With CodeCraft, you can do interesting things with the sensors.",
+            "icon_map": {
+              "64x64": {
+                "full_path": "icon5.png",
+                "url": "http://localhost:8081/api/v3/projects/codecraft/rev0/files/icon5.png",
+              },
             },
-          },
-          "idp_user_id": "CyberSherpa",
-          "license_type": "MIT",
-          "name": "CodeCraft",
-          "published_at": "2024-05-23T14:01:16.975Z",
-          "revision": 0,
-          "slug": "codecraft",
-        }
-      `);
+            "idp_user_id": "CyberSherpa",
+            "license_type": "MIT",
+            "name": "CodeCraft",
+            "published_at": "2024-05-23T14:01:16.975Z",
+            "revision": 0,
+            "slug": "codecraft",
+          }
+        `);
     });
 
     test("GET /api/v3/project-summaries should not contain unpublished apps", async () => {
       const res = await request(app).get("/api/v3/project-summaries");
       expect(res.statusCode).toBe(200);
       expect(
-        res.body.find((app: ProjectSummary) => !app.published_at)?.name
+        res.body.find((app: ProjectSummary) => !app.published_at)
       ).toBeUndefined();
+    });
+
+    test("GET /api/v3/project-summaries should not contain hidden apps unless the slug is given", async () => {
+      const res = await request(app).get("/api/v3/project-summaries");
+      expect(res.statusCode).toBe(200);
+      expect(
+        res.body.find((app: ProjectSummary) => app.slug === "nanogames")
+      ).toBeUndefined();
+      expect(
+        res.body.find((app: ProjectSummary) => app.hidden)
+      ).toBeUndefined();
+
+      const withSlugRes = await request(app).get(
+        "/api/v3/project-summaries?slugs=nanogames"
+      );
+      expect(withSlugRes.statusCode).toBe(200);
+      expect(
+        withSlugRes.body.find((app: ProjectSummary) => app.slug === "nanogames")
+          ?.hidden
+      ).toBe(true);
     });
 
     test("GET /api/v3/project-summaries with device filter", async () => {

--- a/packages/backend/src/db/sqlHelpers/projectQuery.ts
+++ b/packages/backend/src/db/sqlHelpers/projectQuery.ts
@@ -32,12 +32,11 @@ export const projectQueryResponseToReadModel = (
   enrichedDBProject: ProjectQueryResponse
 ): ProjectSummary => {
   const appMetadata = enrichedDBProject.app_metadata;
-  return {
+  const projectSummary: ProjectSummary = {
     idp_user_id: enrichedDBProject.idp_user_id,
     categories: appMetadata.categories,
     description: appMetadata.description,
     // download_counter: undefined, // TODO
-    git: enrichedDBProject.git,
     license_type: appMetadata.license_type,
     name: appMetadata.name ?? enrichedDBProject.slug,
     published_at:
@@ -70,6 +69,13 @@ export const projectQueryResponseToReadModel = (
       ) as IconMapWithUrls),
     badges: appMetadata.badges,
   };
+  if (appMetadata.hidden) {
+    projectSummary.hidden = appMetadata.hidden;
+  }
+  if (enrichedDBProject.git) {
+    projectSummary.git = enrichedDBProject.git;
+  }
+  return projectSummary;
 };
 
 export type ProjectQueryResponse = DBProject & DBVersion;

--- a/packages/backend/src/dev/populateDB.ts
+++ b/packages/backend/src/dev/populateDB.ts
@@ -278,6 +278,12 @@ const writeDraftAppFiles = async (
     categories,
     icon_map: iconRelativePath ? { "64x64": iconRelativePath } : undefined,
   };
+  if (semiRandomNumber % 2 === 0) {
+    appMetadata.hidden = false;
+  }
+  if (semiRandomNumber % 9 === 0) {
+    appMetadata.hidden = true;
+  }
   if (semanticVersion !== "") {
     appMetadata.version = semanticVersion;
   }

--- a/packages/shared/src/domain/readModels/project/ProjectDetails.ts
+++ b/packages/shared/src/domain/readModels/project/ProjectDetails.ts
@@ -42,6 +42,7 @@ export type IconMapWithUrls = {
 
 export interface ProjectSummary extends ProjectCore {
   // Computed
+  hidden?: boolean;
   name: string;
   published_at?: Date; // Can be undefined if not published yet
   icon_map?: IconMapWithUrls; // Relative path to the icon of the project
@@ -96,6 +97,7 @@ export const iconMapWithUrlsSchema = z
 
 export const projectSummarySchema = projectCoreSchema.extend({
   name: z.string(),
+  hidden: z.boolean().optional(),
   published_at: z.date().optional(),
   icon_map: iconMapWithUrlsSchema.optional(),
   license_type: z.string().optional(),


### PR DESCRIPTION
Hides the apps that have the hidden property in the app metadata json from the project summaries.
- Only an api feature, not added to ui currentlyl
- 2 exceptions:
  - if the specific slug is given as query parameter
  - when requesting user's draft projects