### PR TITLE
Add long description field to app metadata and UI

### DIFF
--- a/packages/backend/src/dev/populate-db/createSemiRandomAppdata.ts
+++ b/packages/backend/src/dev/populate-db/createSemiRandomAppdata.ts
@@ -62,6 +62,7 @@ export async function createSemiRandomAppdata(
   const semiRandomNumber = await stringToSemiRandomNumber(projectName);
   const projectSlug = projectName.toLowerCase();
   const description = await getDescription(projectName);
+  const longDescription = getLongDescription(projectName, semiRandomNumber);
   const userId = semiRandomNumber % USERS.length;
 
   const { created_at, updated_at } = await getSemiRandomDates(projectName);
@@ -97,7 +98,9 @@ export async function createSemiRandomAppdata(
   const appMetadata: AppMetadataJSON = {
     name: projectName,
     description,
+    long_description: longDescription,
     author: USERS[userId]!,
+
     license_type: "MIT",
     badges,
     categories,
@@ -138,4 +141,17 @@ async function getDescription(appName: string) {
     case 3:
       return `${appName} is just some silly test app.`;
   }
+}
+
+function getLongDescription(appName: string, semiRandomNumber: number) {
+  // Deterministic 50% coverage, similar to the rest of the semirandom fixtures.
+  if (semiRandomNumber % 2 !== 0) {
+    return undefined;
+  }
+
+  return `Lorem ipsum dolor sit amet, consectetur adipiscing elit. ${appName} posuere orci sed odio faucibus, vitae varius velit faucibus. Integer tempus, nisl eu porttitor fermentum, purus nibh hendrerit velit, quis volutpat dolor felis eu sem.
+
+Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. ${appName} facilisis nunc id lorem bibendum, non congue neque elementum.
+
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`;
 }

--- a/packages/frontend/src/__test__/fixtures/dummyApps.ts
+++ b/packages/frontend/src/__test__/fixtures/dummyApps.ts
@@ -5,6 +5,7 @@ type DummyData = {
   slug: string;
   name: string;
   description: string;
+  long_description?: string;
   categories: string[];
   revision: number;
   badges: string[];
@@ -15,6 +16,7 @@ const dummyData: DummyData[] = [
     slug: "dummy-app-1",
     name: "Dummy App 1",
     description: "A test app",
+    long_description: "This is a longer test app description.",
     categories: ["Silly"],
     revision: 1,
     badges: ["mch2022", "why2025"],

--- a/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
@@ -8,14 +8,26 @@ const AppDescription: React.FC<{ project: ProjectDetails }> = ({
 }) => (
   <section className="card bg-base-200 shadow-lg">
     <div className="card-body">
-    <h2 className="card-title text-2xl mb-4">Description</h2>
-    <div className="prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none text-base-content/80 space-y-4">
-      {app_metadata.description ? (
-        <p className="whitespace-pre-wrap">{app_metadata.description}</p>
-      ) : (
-        <p>No description provided.</p>
-      )}
-    </div>
+      <h2 className="card-title text-2xl mb-4">Description</h2>
+      <div className="prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none text-base-content/80 space-y-4">
+        {app_metadata.description ? (
+          <div>
+            <h3 className="text-base font-semibold mb-2">Short description</h3>
+            <p className="whitespace-pre-wrap">{app_metadata.description}</p>
+          </div>
+        ) : null}
+
+        {app_metadata.long_description ? (
+          <div>
+            <h3 className="text-base font-semibold mb-2">Long description</h3>
+            <p className="whitespace-pre-wrap">{app_metadata.long_description}</p>
+          </div>
+        ) : null}
+
+        {!app_metadata.description && !app_metadata.long_description ? (
+          <p>No description provided.</p>
+        ) : null}
+      </div>
     </div>
   </section>
 );

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
@@ -22,6 +22,9 @@ describe("AppDetailPage", { timeout: 1000_000 }, () => {
 
     expect(screen.getByTestId("app-detail-name")).toHaveTextContent(app.name!);
     expect(await screen.findByText(app.description!)).toBeInTheDocument();
+    expect(
+      await screen.findByText("This is a longer test app description.")
+    ).toBeInTheDocument();
     expect(screen.getAllByText(app.categories![0]!).length).toBeGreaterThan(0);
     if (app.badges && app.badges.length > 0) {
       expect(screen.queryAllByText(app.badges[0]!).length).toBeGreaterThan(0);

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.test.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.test.tsx
@@ -9,6 +9,7 @@ const baseForm: ProjectEditFormData = {
   name: "Demo",
   author: "Author",
   description: "Desc",
+  long_description: "Long Desc",
   git_url: "https://github.com/demo/repo",
   version: "1.0.0",
   hidden: false,
@@ -24,7 +25,8 @@ describe("AppEditBasicInfo", () => {
       "https://github.com/demo/repo"
     );
     expect(screen.getByLabelText(/version/i)).toHaveValue("1.0.0");
-    expect(screen.getByLabelText(/description/i)).toHaveValue("Desc");
+    expect(screen.getByLabelText(/^description$/i)).toHaveValue("Desc");
+    expect(screen.getByLabelText(/long description/i)).toHaveValue("Long Desc");
     expect(screen.getByLabelText(/hidden/i)).not.toBeChecked();
   });
 
@@ -73,10 +75,16 @@ describe("AppEditBasicInfo", () => {
     expect(onChange).toHaveBeenLastCalledWith({ version: "2.1.0" });
     onChange.mockClear();
 
-    await user.clear(screen.getByLabelText(/description/i));
-    await user.type(screen.getByLabelText(/description/i), "New Desc");
-    expect(screen.getByLabelText(/description/i)).toHaveValue("New Desc");
+    await user.clear(screen.getByLabelText(/^description$/i));
+    await user.type(screen.getByLabelText(/^description$/i), "New Desc");
+    expect(screen.getByLabelText(/^description$/i)).toHaveValue("New Desc");
     expect(onChange).toHaveBeenLastCalledWith({ description: "New Desc" });
+    onChange.mockClear();
+
+    await user.clear(screen.getByLabelText(/long description/i));
+    await user.type(screen.getByLabelText(/long description/i), "New Long Desc");
+    expect(screen.getByLabelText(/long description/i)).toHaveValue("New Long Desc");
+    expect(onChange).toHaveBeenLastCalledWith({ long_description: "New Long Desc" });
     onChange.mockClear();
 
     await user.click(screen.getByLabelText(/hidden/i));

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -77,17 +77,32 @@ const AppEditBasicInfo: React.FC<{
           </div>
 
           {/* Description */}
-          <div className="form-control">
-            <label htmlFor="description" className="label">
-              <span className="label-text">Description</span>
-            </label>
-            <textarea
-              id="description"
-              rows={4}
-              className="textarea textarea-bordered w-full"
-              value={form.description || ""}
-              onChange={(e) => onChange({ description: e.target.value })}
-            />
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="form-control">
+              <label htmlFor="description" className="label">
+                <span className="label-text">Description</span>
+              </label>
+              <textarea
+                id="description"
+                rows={4}
+                className="textarea textarea-bordered w-full"
+                value={form.description || ""}
+                onChange={(e) => onChange({ description: e.target.value })}
+              />
+            </div>
+
+            <div className="form-control">
+              <label htmlFor="longDescription" className="label">
+                <span className="label-text">Long Description</span>
+              </label>
+              <textarea
+                id="longDescription"
+                rows={4}
+                className="textarea textarea-bordered w-full"
+                value={form.long_description || ""}
+                onChange={(e) => onChange({ long_description: e.target.value })}
+              />
+            </div>
           </div>
 
           {/* Hidden Toggle */}

--- a/packages/shared/src/domain/readModels/project/AppMetadataJSON.ts
+++ b/packages/shared/src/domain/readModels/project/AppMetadataJSON.ts
@@ -20,6 +20,7 @@ export interface AppMetadataJSON {
   project_type?: "app" | "library" | "firmware" | "other";
   hidden?: boolean;
   description?: string;
+  long_description?: string;
   git_url?: string;
   version?: string;
   categories?: CategoryName[];
@@ -88,6 +89,10 @@ export const appMetadataJSONSchema = z.object({
     .describe(
       "Some more details about the app. Allows users to decide whether they want to install the app."
     ),
+  long_description: z
+    .string()
+    .optional()
+    .describe("Longer description with more detailed app information."),
   categories: z
     .array(categoryNameSchema)
     .optional()


### PR DESCRIPTION
## Summary
- add optional long_description to AppMetadataJSON schema and type
- add a Long Description field in app edit basic info next to Description
- show both short and long descriptions on the app detail page
- update relevant frontend tests and fixtures

## Notes
- branch is based on upstream main
- local test execution in this environment currently hits an existing React/Vitest issue (React.act is not a function) unrelated to this change