### PR TITLE
feat: Add audio file preview support

### DIFF
--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
@@ -97,6 +97,19 @@ const mockProject: ProjectDetails = {
       },
       {
         dir: "",
+        name: "Warning",
+        ext: "wav",
+        mimetype: "audio/x-wav",
+        size_of_content: 8264,
+        sha256: "f".repeat(64),
+        size_formatted: "8.07 KB",
+        full_path: "sounds/Warning.wav",
+        url: "http://example.com/sounds/Warning.wav",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
         name: "document",
         ext: "pdf",
         mimetype: "application/pdf",
@@ -163,6 +176,23 @@ describe("AppCodePreview", () => {
     await waitFor(() => {
       expect(img).toHaveAttribute("src", "http://example.com/image.png");
     });
+  });
+
+  it("shows an audio player for WAV files", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    fireEvent.click(screen.getByText("sounds/Warning.wav"));
+
+    expect(await screen.findByText("Audio file")).toBeInTheDocument();
+    const audio = document.querySelector("audio");
+    expect(audio).toHaveAttribute("controls");
+    expect(audio).toHaveAttribute(
+      "src",
+      "http://example.com/sounds/Warning.wav"
+    );
+    expect(
+      screen.queryByText("Preview not available for this file type.")
+    ).not.toBeInTheDocument();
   });
 
   it("shows JSON preview with pretty print functionality", async () => {

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -212,6 +212,35 @@ const ImagePreview: React.FC<{ file: FileMetadata; imageBlob?: Blob }> = ({
   );
 };
 
+const AudioPreview: React.FC<{ file: FileMetadata; audioBlob?: Blob }> = ({
+  file,
+  audioBlob,
+}) => {
+  const [audioUrl, setAudioUrl] = useState(file.url || "");
+
+  useEffect(() => {
+    if (audioBlob) {
+      const url = URL.createObjectURL(audioBlob);
+      setAudioUrl(url);
+      return () => URL.revokeObjectURL(url);
+    }
+    setAudioUrl(file.url || "");
+  }, [audioBlob, file.url]);
+
+  return (
+    <div>
+      <div className="mb-2">
+        <span className="text-base-content/80 text-sm">Audio file</span>
+      </div>
+      {audioUrl && (
+        <audio className="w-full" controls preload="metadata" src={audioUrl}>
+          Your browser does not support audio playback.
+        </audio>
+      )}
+    </div>
+  );
+};
+
 // No Preview Component for unsupported types
 const NoPreview: React.FC<{ mimetype: string }> = ({ mimetype }) => {
   return (
@@ -230,7 +259,7 @@ const renderFilePreview = (
   currentFile: FileMetadata | null,
   fileContent: string | null,
   isDark: boolean,
-  imageBlob?: Blob
+  previewBlob?: Blob
 ): React.ReactElement => {
   if (loading) {
     return <div className="opacity-60">Loading file...</div>;
@@ -251,7 +280,9 @@ const renderFilePreview = (
 
   switch (previewType) {
     case "image":
-      return <ImagePreview file={currentFile} imageBlob={imageBlob} />;
+      return <ImagePreview file={currentFile} imageBlob={previewBlob} />;
+    case "audio":
+      return <AudioPreview file={currentFile} audioBlob={previewBlob} />;
     case "json":
       return fileContent ? (
         <JsonPreview content={fileContent} isDark={isDark} />
@@ -299,7 +330,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
   const isDark = useIsDarkTheme();
   const [previewedFile, setPreviewedFile] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
-  const [imageBlob, setImageBlob] = useState<Blob | null>(null);
+  const [previewBlob, setPreviewBlob] = useState<Blob | null>(null);
   const [loading, setLoading] = useState(false);
 
   // Get the currently previewed file metadata
@@ -315,7 +346,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
     if (!files?.length) {
       setPreviewedFile(null);
       setFileContent(null);
-      setImageBlob(null);
+      setPreviewBlob(null);
       return;
     }
     const initFile = files.find(
@@ -328,7 +359,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
     } else {
       setPreviewedFile(null);
       setFileContent(null);
-      setImageBlob(null);
+      setPreviewBlob(null);
     }
   }, [files, externalPreviewedFile]);
 
@@ -336,7 +367,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
   useEffect(() => {
     if (!previewedFile || !currentFile) {
       setFileContent(null);
-      setImageBlob(null);
+      setPreviewBlob(null);
       return;
     }
 
@@ -346,7 +377,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
       "unsupported"
     ) {
       setFileContent(null);
-      setImageBlob(null);
+      setPreviewBlob(null);
       setLoading(false);
       return;
     }
@@ -366,22 +397,23 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
           if (response.status === 200 && response.body) {
             const blob = response.body as Blob;
 
-            // For images, store the blob for display
-            if (
-              getPreviewType(currentFile.mimetype, currentFile.full_path) ===
-              "image"
-            ) {
-              setImageBlob(blob);
+            // Binary previews need an object URL for authenticated draft blobs.
+            const previewType = getPreviewType(
+              currentFile.mimetype,
+              currentFile.full_path
+            );
+            if (previewType === "image" || previewType === "audio") {
+              setPreviewBlob(blob);
               setFileContent(null);
             } else {
               // For text files, convert blob to text
               const text = await blob.text();
               setFileContent(text);
-              setImageBlob(null);
+              setPreviewBlob(null);
             }
           } else {
             setFileContent("// Unable to load file");
-            setImageBlob(null);
+            setPreviewBlob(null);
           }
         } else {
           // Published mode - use public API
@@ -394,26 +426,27 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
 
           if (res.status === 200) {
             if (
-              getPreviewType(currentFile.mimetype, currentFile.full_path) ===
-              "image"
+              ["image", "audio"].includes(
+                getPreviewType(currentFile.mimetype, currentFile.full_path)
+              )
             ) {
-              // For published images, we use the file.url directly (no blob needed)
-              setImageBlob(null);
+              // Published binary previews can use the file URL directly.
+              setPreviewBlob(null);
               setFileContent(null);
             } else if (typeof res.body === "string") {
               setFileContent(res.body);
-              setImageBlob(null);
+              setPreviewBlob(null);
             } else if (res.body instanceof Blob) {
               const text = await res.body.text();
               setFileContent(text);
-              setImageBlob(null);
+              setPreviewBlob(null);
             } else {
               setFileContent("// Unable to display file content");
-              setImageBlob(null);
+              setPreviewBlob(null);
             }
           } else {
             setFileContent("// Unable to load file");
-            setImageBlob(null);
+            setPreviewBlob(null);
           }
         }
       } catch (error) {
@@ -421,7 +454,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
         setFileContent(
           "// Network error - please check your connection and try again"
         );
-        setImageBlob(null);
+        setPreviewBlob(null);
       } finally {
         setLoading(false);
       }
@@ -522,7 +555,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
             currentFile,
             fileContent,
             isDark,
-            imageBlob || undefined
+            previewBlob || undefined
           )}
         </div>
       </div>

--- a/packages/frontend/src/utils/filePreview.test.ts
+++ b/packages/frontend/src/utils/filePreview.test.ts
@@ -6,6 +6,11 @@ describe("getPreviewType", () => {
     expect(getPreviewType("image/png", "icon.png")).toBe("image");
   });
 
+  it("detects audio types by mimetype", () => {
+    expect(getPreviewType("audio/x-wav", "sounds/Warning.wav")).toBe("audio");
+    expect(getPreviewType("audio/mpeg", "sounds/music.mp3")).toBe("audio");
+  });
+
   it("detects json types by mimetype", () => {
     expect(getPreviewType("application/json", "data.json")).toBe("json");
   });
@@ -22,6 +27,7 @@ describe("getPreviewType", () => {
     expect(getPreviewType("application/octet-stream", "script.py")).toBe("python");
     expect(getPreviewType("application/octet-stream", "notes.md")).toBe("text");
     expect(getPreviewType("application/octet-stream", "photo.jpg")).toBe("image");
+    expect(getPreviewType("application/octet-stream", "sounds/Warning.wav")).toBe("audio");
   });
 
   it("returns unsupported when no match is found", () => {

--- a/packages/frontend/src/utils/filePreview.ts
+++ b/packages/frontend/src/utils/filePreview.ts
@@ -3,7 +3,25 @@ import {
   TEXT_FILE_EXTENSIONS,
 } from "@utils/fileUtils.ts";
 
-export type PreviewType = "image" | "json" | "python" | "text" | "unsupported";
+export type PreviewType =
+  | "audio"
+  | "image"
+  | "json"
+  | "python"
+  | "text"
+  | "unsupported";
+
+const AUDIO_FILE_EXTENSIONS = [
+  "aac",
+  "flac",
+  "m4a",
+  "mp3",
+  "oga",
+  "ogg",
+  "opus",
+  "wav",
+  "webm",
+];
 
 export const getPreviewType = (
   mimetype: string,
@@ -11,6 +29,9 @@ export const getPreviewType = (
 ): PreviewType => {
   if (mimetype.startsWith("image/")) {
     return "image";
+  }
+  if (mimetype.startsWith("audio/")) {
+    return "audio";
   }
   if (mimetype === "application/json") {
     return "json";
@@ -44,6 +65,9 @@ export const getPreviewType = (
     }
     if (IMAGE_FILE_EXTENSIONS.includes(extension as (typeof IMAGE_FILE_EXTENSIONS)[number])) {
       return "image";
+    }
+    if (AUDIO_FILE_EXTENSIONS.includes(extension)) {
+      return "audio";
     }
   }
 

--- a/packages/frontend/src/utils/filePreview.ts
+++ b/packages/frontend/src/utils/filePreview.ts
@@ -1,4 +1,5 @@
 import {
+  AUDIO_FILE_EXTENSIONS,
   IMAGE_FILE_EXTENSIONS,
   TEXT_FILE_EXTENSIONS,
 } from "@utils/fileUtils.ts";
@@ -10,18 +11,6 @@ export type PreviewType =
   | "python"
   | "text"
   | "unsupported";
-
-const AUDIO_FILE_EXTENSIONS = [
-  "aac",
-  "flac",
-  "m4a",
-  "mp3",
-  "oga",
-  "ogg",
-  "opus",
-  "wav",
-  "webm",
-];
 
 export const getPreviewType = (
   mimetype: string,
@@ -60,13 +49,25 @@ export const getPreviewType = (
     if (extension === "json") {
       return "json";
     }
-    if (TEXT_FILE_EXTENSIONS.includes(extension as (typeof TEXT_FILE_EXTENSIONS)[number])) {
+    if (
+      TEXT_FILE_EXTENSIONS.includes(
+        extension as (typeof TEXT_FILE_EXTENSIONS)[number]
+      )
+    ) {
       return "text";
     }
-    if (IMAGE_FILE_EXTENSIONS.includes(extension as (typeof IMAGE_FILE_EXTENSIONS)[number])) {
+    if (
+      IMAGE_FILE_EXTENSIONS.includes(
+        extension as (typeof IMAGE_FILE_EXTENSIONS)[number]
+      )
+    ) {
       return "image";
     }
-    if (AUDIO_FILE_EXTENSIONS.includes(extension)) {
+    if (
+      AUDIO_FILE_EXTENSIONS.includes(
+        extension as (typeof AUDIO_FILE_EXTENSIONS)[number]
+      )
+    ) {
       return "audio";
     }
   }

--- a/packages/frontend/src/utils/fileUtils.ts
+++ b/packages/frontend/src/utils/fileUtils.ts
@@ -11,16 +11,61 @@ export const extractFilename = (filePath: string): string => {
  * File extensions that should be treated as text files for preview purposes
  */
 export const TEXT_FILE_EXTENSIONS = [
-  "js", "jsx", "ts", "tsx", "html", "css", "scss", "sass", "less", 
-  "xml", "yaml", "yml", "md", "sh", "bash", "c", "cpp", "java", 
-  "php", "rb", "go", "rs", "sql", "txt"
+  "js",
+  "jsx",
+  "ts",
+  "tsx",
+  "html",
+  "css",
+  "scss",
+  "sass",
+  "less",
+  "xml",
+  "yaml",
+  "yml",
+  "md",
+  "sh",
+  "bash",
+  "c",
+  "cpp",
+  "java",
+  "php",
+  "rb",
+  "go",
+  "rs",
+  "sql",
+  "txt",
 ] as const;
 
 /**
  * File extensions that should be treated as image files for preview purposes
  */
 export const IMAGE_FILE_EXTENSIONS = [
-  "png", "jpg", "jpeg", "gif", "svg", "webp", "bmp", "tiff", "tif", "avif"
+  "png",
+  "jpg",
+  "jpeg",
+  "gif",
+  "svg",
+  "webp",
+  "bmp",
+  "tiff",
+  "tif",
+  "avif",
+] as const;
+
+/**
+ * File extensions that should be treated as audio files for preview purposes
+ */
+export const AUDIO_FILE_EXTENSIONS = [
+  "aac",
+  "flac",
+  "m4a",
+  "mp3",
+  "oga",
+  "ogg",
+  "opus",
+  "wav",
+  "webm",
 ] as const;
 
 export const NON_EXECUTABLE_EXTENSIONS = [


### PR DESCRIPTION
Added audio player preview for WAV, MP3, and other audio formats in the AppCodePreview component. Created AudioPreview component mirroring ImagePreview, extended file type detection to recognize audio mimetypes and extensions (wav, mp3, flac, ogg, etc.), and refactored blob storage from image-specific to generic preview blob handling.

Closes #396 