### PR TITLE
fix: correct uploaded file MIME types and serve files with Content-Type

### DIFF
--- a/packages/backend/src/controllers/public-rest.spec.ts
+++ b/packages/backend/src/controllers/public-rest.spec.ts
@@ -538,6 +538,20 @@ describe(
       }
     );
 
+    test.each(["latest", "rev1"])(
+      "GET /projects/{slug}/%s/files/icon5.png sets Content-Type and renders inline",
+      async (revision) => {
+        const getRes = await request(app).get(
+          `/api/v3/projects/codecraft/${revision}/files/icon5.png`
+        );
+        expect(getRes.statusCode).toBe(200);
+        expect(getRes.headers["content-type"]).toEqual("image/png");
+        expect(getRes.headers["content-disposition"]).toEqual(
+          'inline; filename="icon5.png"'
+        );
+      }
+    );
+
     describe("ping should return pong", () => {
       test.each([
         { id: "testid", mac: "testmac" },

--- a/packages/backend/src/controllers/ts-rest/publicRestRouter.ts
+++ b/packages/backend/src/controllers/ts-rest/publicRestRouter.ts
@@ -13,36 +13,52 @@ import { noContent, nok, ok } from "@controllers/ts-rest/httpResponses";
 import { Readable } from "node:stream";
 import { RouterImplementation } from "@ts-rest/express/src/lib/types";
 import { ProjectLatestRevisions } from "@shared/domain/readModels/project/ProjectRevision";
+import { isSafeToRenderInline } from "@util/mimeTypeDetection";
+
+const setFileResponseHeaders = (
+  res: { setHeader: (name: string, value: string) => void },
+  filePath: string,
+  mimetype: string | undefined
+) => {
+  if (mimetype) {
+    res.setHeader("Content-Type", mimetype);
+  }
+  const disposition = isSafeToRenderInline(mimetype) ? "inline" : "attachment";
+  res.setHeader(
+    "Content-Disposition",
+    `${disposition}; filename="${filePath}"`
+  );
+};
 
 const createFilesRouter = (badgeHubData: BadgeHubData) => {
   const filesRouter: RouterImplementation<typeof publicFilesContracts> = {
     getLatestPublishedFile: async ({ params: { slug, filePath }, res }) => {
-      const file = await badgeHubData.getFileContents(slug, "latest", filePath);
+      const [file, fileMetadata] = await Promise.all([
+        badgeHubData.getFileContents(slug, "latest", filePath),
+        badgeHubData.getFileMetadata(slug, "latest", filePath),
+      ]);
       if (!file) {
         return nok(404, `No app with slug '${slug}' found`);
       }
+      setFileResponseHeaders(res, filePath, fileMetadata?.mimetype);
       const data = Readable.from(file);
-      res.setHeader(
-        "Content-Disposition",
-        `attachment; filename="${filePath}"`
-      );
       return ok(data);
     },
     getFileForRevision: async ({
       params: { slug, revision, filePath },
       res,
     }) => {
-      const file = await badgeHubData.getFileContents(slug, revision, filePath);
+      const [file, fileMetadata] = await Promise.all([
+        badgeHubData.getFileContents(slug, revision, filePath),
+        badgeHubData.getFileMetadata(slug, revision, filePath),
+      ]);
       if (!file) {
         return nok(
           404,
           `No app with slug '${slug}' and revision '${revision}' found`
         );
       }
-      res.setHeader(
-        "Content-Disposition",
-        `attachment; filename="${filePath}"`
-      );
+      setFileResponseHeaders(res, filePath, fileMetadata?.mimetype);
       // Enable public caching for immutable revisioned files (1 year)
       res.setHeader("Cache-Control", "public, max-age=31536000, immutable");
       const data = Readable.from(file);

--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -69,6 +69,25 @@ describe("MIME Type Detection", () => {
     );
   });
 
+  it("should treat .mpk uploads (MicroPythonOS app packages) as binary regardless of client MIME type", () => {
+    // Explicit binary type from a well-behaved client stays binary.
+    expect(detectMimeType("application/octet-stream", "app.mpk")).toBe(
+      "application/octet-stream"
+    );
+    // publish_badgehub.py-style upload without a real content type must not
+    // leave a binary package stored as text/plain.
+    expect(detectMimeType("text/plain", "com.example.app.mpk")).toBe(
+      "application/octet-stream"
+    );
+    expect(detectMimeType(undefined, "app.mpk")).toBe(
+      "application/octet-stream"
+    );
+    // A specific, trusted client-provided type is still honored.
+    expect(detectMimeType("application/zip", "app.mpk")).toBe(
+      "application/zip"
+    );
+  });
+
   it("should treat generic browser MIME types case-insensitively and ignore parameters", () => {
     expect(detectMimeType("Text/Plain; charset=utf-8", "icon.png")).toBe(
       "image/png"
@@ -96,6 +115,9 @@ describe("isSafeToRenderInline", () => {
     expect(isSafeToRenderInline("text/html")).toBe(false);
     expect(isSafeToRenderInline("text/x-python")).toBe(false);
     expect(isSafeToRenderInline("application/json")).toBe(false);
+    // .mpk packages are stored as application/octet-stream and must be
+    // served as a download, never rendered inline.
+    expect(isSafeToRenderInline("application/octet-stream")).toBe(false);
   });
 
   it("rejects missing MIME type", () => {

--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -64,6 +64,15 @@ describe("MIME Type Detection", () => {
       "audio/wave"
     );
   });
+
+  it("should treat generic browser MIME types case-insensitively and ignore parameters", () => {
+    expect(detectMimeType("Text/Plain; charset=utf-8", "icon.png")).toBe(
+      "image/png"
+    );
+    expect(detectMimeType("Application/X-Unknown", "style.css")).toBe(
+      "text/css"
+    );
+  });
 });
 
 describe("isSafeToRenderInline", () => {
@@ -72,6 +81,7 @@ describe("isSafeToRenderInline", () => {
     expect(isSafeToRenderInline("image/jpeg")).toBe(true);
     expect(isSafeToRenderInline("audio/wave")).toBe(true);
     expect(isSafeToRenderInline("audio/x-wav")).toBe(true);
+    expect(isSafeToRenderInline("Image/PNG; charset=binary")).toBe(true);
   });
 
   it("rejects SVG despite being an image type, since it can contain script", () => {

--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -48,6 +48,10 @@ describe("MIME Type Detection", () => {
 
   it("should handle empty or missing browser MIME type", () => {
     expect(detectMimeType("", "test.py")).toBe("text/x-python");
+    expect(detectMimeType(undefined, "test.py")).toBe("text/x-python");
+    expect(detectMimeType(null, "file.unknown")).toBe(
+      "application/octet-stream"
+    );
     expect(detectMimeType("", "file.unknown")).toBe("application/octet-stream");
   });
 

--- a/packages/backend/src/util/mimeTypeDetection.spec.ts
+++ b/packages/backend/src/util/mimeTypeDetection.spec.ts
@@ -1,38 +1,90 @@
-import { describe, expect, it } from 'vitest';
-import { detectMimeType } from './mimeTypeDetection';
+import { describe, expect, it } from "vitest";
+import { detectMimeType, isSafeToRenderInline } from "./mimeTypeDetection";
 
-describe('MIME Type Detection', () => {
-  it('should use browser MIME type when it is specific and reliable', () => {
-    expect(detectMimeType('text/x-python', 'test.py')).toBe('text/x-python');
-    expect(detectMimeType('application/json', 'config.json')).toBe('application/json');
-    expect(detectMimeType('image/png', 'icon.png')).toBe('image/png');
+describe("MIME Type Detection", () => {
+  it("should use browser MIME type when it is specific and reliable", () => {
+    expect(detectMimeType("text/x-python", "test.py")).toBe("text/x-python");
+    expect(detectMimeType("application/json", "config.json")).toBe(
+      "application/json"
+    );
+    expect(detectMimeType("image/png", "icon.png")).toBe("image/png");
   });
 
-  it('should fallback to extension-based detection for generic browser MIME types', () => {
-    expect(detectMimeType('application/octet-stream', 'script.py')).toBe('text/x-python');
-    expect(detectMimeType('application/octet', 'data.json')).toBe('application/json');
-    expect(detectMimeType('application/x-unknown', 'style.css')).toBe('text/css');
+  it("should fallback to extension-based detection for generic browser MIME types", () => {
+    expect(detectMimeType("application/octet-stream", "script.py")).toBe(
+      "text/x-python"
+    );
+    expect(detectMimeType("application/octet", "data.json")).toBe(
+      "application/json"
+    );
+    expect(detectMimeType("application/x-unknown", "style.css")).toBe(
+      "text/css"
+    );
   });
 
-  it('should handle various file extensions correctly', () => {
-    expect(detectMimeType('application/octet-stream', 'app.js')).toBe('application/javascript');
-    expect(detectMimeType('application/octet-stream', 'component.tsx')).toBe('text/typescript-jsx');
-    expect(detectMimeType('application/octet-stream', 'readme.md')).toBe('text/markdown');
-    expect(detectMimeType('application/octet-stream', 'config.yml')).toBe('text/yaml');
+  it("should handle various file extensions correctly", () => {
+    expect(detectMimeType("application/octet-stream", "app.js")).toBe(
+      "application/javascript"
+    );
+    expect(detectMimeType("application/octet-stream", "component.tsx")).toBe(
+      "text/typescript-jsx"
+    );
+    expect(detectMimeType("application/octet-stream", "readme.md")).toBe(
+      "text/markdown"
+    );
+    expect(detectMimeType("application/octet-stream", "config.yml")).toBe(
+      "text/yaml"
+    );
   });
 
-  it('should return browser MIME type as final fallback for unknown extensions', () => {
-    expect(detectMimeType('application/octet-stream', 'file.unknown')).toBe('application/octet-stream');
-    expect(detectMimeType('application/custom', 'file.unknown')).toBe('application/custom');
+  it("should return browser MIME type as final fallback for unknown extensions", () => {
+    expect(detectMimeType("application/octet-stream", "file.unknown")).toBe(
+      "application/octet-stream"
+    );
+    expect(detectMimeType("application/custom", "file.unknown")).toBe(
+      "application/custom"
+    );
   });
 
-  it('should handle empty or missing browser MIME type', () => {
-    expect(detectMimeType('', 'test.py')).toBe('text/x-python');
-    expect(detectMimeType('', 'file.unknown')).toBe('application/octet-stream');
+  it("should handle empty or missing browser MIME type", () => {
+    expect(detectMimeType("", "test.py")).toBe("text/x-python");
+    expect(detectMimeType("", "file.unknown")).toBe("application/octet-stream");
   });
 
-  it('should handle files without extensions', () => {
-    expect(detectMimeType('text/plain', 'README')).toBe('text/plain');
-    expect(detectMimeType('application/octet-stream', 'Dockerfile')).toBe('application/octet-stream');
+  it("should handle files without extensions", () => {
+    expect(detectMimeType("text/plain", "README")).toBe("text/plain");
+    expect(detectMimeType("application/octet-stream", "Dockerfile")).toBe(
+      "application/octet-stream"
+    );
+  });
+
+  it("should fallback to extension-based detection when browser reports text/plain for a binary file", () => {
+    expect(detectMimeType("text/plain", "icon_64x64.png")).toBe("image/png");
+    expect(detectMimeType("text/plain", "sounds/Warning.wav")).toBe(
+      "audio/wave"
+    );
+  });
+});
+
+describe("isSafeToRenderInline", () => {
+  it("allows image and audio types", () => {
+    expect(isSafeToRenderInline("image/png")).toBe(true);
+    expect(isSafeToRenderInline("image/jpeg")).toBe(true);
+    expect(isSafeToRenderInline("audio/wave")).toBe(true);
+    expect(isSafeToRenderInline("audio/x-wav")).toBe(true);
+  });
+
+  it("rejects SVG despite being an image type, since it can contain script", () => {
+    expect(isSafeToRenderInline("image/svg+xml")).toBe(false);
+  });
+
+  it("rejects non-image/audio types", () => {
+    expect(isSafeToRenderInline("text/html")).toBe(false);
+    expect(isSafeToRenderInline("text/x-python")).toBe(false);
+    expect(isSafeToRenderInline("application/json")).toBe(false);
+  });
+
+  it("rejects missing MIME type", () => {
+    expect(isSafeToRenderInline(undefined)).toBe(false);
   });
 });

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -6,6 +6,9 @@ const customMimeTypes: Record<string, string> = {
   tsx: "text/typescript-jsx",
   ts: "text/typescript",
   jsx: "text/javascript-jsx",
+  // MicroPythonOS app package (a ZIP container); binary, so it must never
+  // inherit a generic text/plain type from the uploading client.
+  mpk: "application/octet-stream",
 };
 
 // Generic MIME types that clients fall back to when they don't know (or

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -29,8 +29,9 @@ export function detectMimeType(
   browserMimeType: string | undefined | null,
   filename: string
 ): string {
-  const normalizedBrowserMimeType = (browserMimeType || "")
-    .split(";")[0]
+  const normalizedBrowserMimeType = (
+    (browserMimeType || "").split(";")[0] ?? ""
+  )
     .trim()
     .toLowerCase();
 
@@ -81,7 +82,9 @@ export function isSafeToRenderInline(mimetype: string | undefined): boolean {
   if (!mimetype) {
     return false;
   }
-  const normalizedMimeType = mimetype.split(";")[0].trim().toLowerCase();
+  const normalizedMimeType = (mimetype.split(";")[0] ?? "")
+    .trim()
+    .toLowerCase();
   if (inlineUnsafeMimeTypes.has(normalizedMimeType)) {
     return false;
   }

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -29,11 +29,17 @@ export function detectMimeType(
   browserMimeType: string,
   filename: string
 ): string {
+  const normalizedBrowserMimeType = browserMimeType
+    .split(";")[0]
+    .trim()
+    .toLowerCase();
+
   // If browser provided a specific, reliable MIME type, use it
   if (
     browserMimeType &&
-    !genericMimeTypes.has(browserMimeType) &&
-    !browserMimeType.startsWith("application/x-")
+    normalizedBrowserMimeType &&
+    !genericMimeTypes.has(normalizedBrowserMimeType) &&
+    !normalizedBrowserMimeType.startsWith("application/x-")
   ) {
     return browserMimeType;
   }
@@ -75,8 +81,12 @@ export function isSafeToRenderInline(mimetype: string | undefined): boolean {
   if (!mimetype) {
     return false;
   }
-  if (inlineUnsafeMimeTypes.has(mimetype)) {
+  const normalizedMimeType = mimetype.split(";")[0].trim().toLowerCase();
+  if (inlineUnsafeMimeTypes.has(normalizedMimeType)) {
     return false;
   }
-  return mimetype.startsWith("image/") || mimetype.startsWith("audio/");
+  return (
+    normalizedMimeType.startsWith("image/") ||
+    normalizedMimeType.startsWith("audio/")
+  );
 }

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -1,45 +1,82 @@
-import mime from 'mime-types';
+import mime from "mime-types";
 
 // Custom mappings for extensions not covered by mime-types library
 const customMimeTypes: Record<string, string> = {
-  'py': 'text/x-python',
-  'tsx': 'text/typescript-jsx',
-  'ts': 'text/typescript',
-  'jsx': 'text/javascript-jsx',
+  py: "text/x-python",
+  tsx: "text/typescript-jsx",
+  ts: "text/typescript",
+  jsx: "text/javascript-jsx",
 };
+
+// Generic MIME types that clients fall back to when they don't know (or
+// didn't set) the real content type. These are never trusted over an
+// extension-based guess.
+const genericMimeTypes = new Set([
+  "application/octet-stream",
+  "application/octet",
+  "text/plain",
+]);
 
 /**
  * Improved MIME type detection that uses file extension as fallback
  * when browser-provided MIME type is generic or unreliable.
- * 
+ *
  * @param browserMimeType - MIME type provided by the browser/multer
  * @param filename - The filename to extract extension from
  * @returns The best-guess MIME type
  */
-export function detectMimeType(browserMimeType: string, filename: string): string {
+export function detectMimeType(
+  browserMimeType: string,
+  filename: string
+): string {
   // If browser provided a specific, reliable MIME type, use it
-  if (browserMimeType && 
-      browserMimeType !== 'application/octet-stream' && 
-      browserMimeType !== 'application/octet' &&
-      !browserMimeType.startsWith('application/x-')) {
+  if (
+    browserMimeType &&
+    !genericMimeTypes.has(browserMimeType) &&
+    !browserMimeType.startsWith("application/x-")
+  ) {
     return browserMimeType;
   }
-  
+
   // Extract extension from filename
-  const extension = filename.toLowerCase().split('.').pop();
-  
+  const extension = filename.toLowerCase().split(".").pop();
+
   // Check our custom mappings first
   if (extension && customMimeTypes[extension]) {
     return customMimeTypes[extension];
   }
-  
+
   // Fallback to mime-types library
   const extensionBasedMimeType = mime.lookup(filename);
-  
+
   if (extensionBasedMimeType) {
     return extensionBasedMimeType;
   }
-  
+
   // Final fallback to browser MIME type (even if generic)
-  return browserMimeType || 'application/octet-stream';
+  return browserMimeType || "application/octet-stream";
+}
+
+// MIME types that are excluded from inline rendering even though their
+// top-level type would otherwise qualify, because browsers can execute
+// script from them (e.g. inline SVG scripts).
+const inlineUnsafeMimeTypes = new Set(["image/svg+xml"]);
+
+/**
+ * Whether a file's MIME type is safe to serve with `Content-Disposition: inline`
+ * so browsers render it directly (e.g. in an `<img>` or `<audio>` tag) instead
+ * of forcing a download. Restricted to image/audio types that browsers cannot
+ * execute as script, to avoid serving user-uploaded content (e.g. HTML/SVG)
+ * inline where it could run as active content.
+ *
+ * @param mimetype - The file's stored MIME type
+ */
+export function isSafeToRenderInline(mimetype: string | undefined): boolean {
+  if (!mimetype) {
+    return false;
+  }
+  if (inlineUnsafeMimeTypes.has(mimetype)) {
+    return false;
+  }
+  return mimetype.startsWith("image/") || mimetype.startsWith("audio/");
 }

--- a/packages/backend/src/util/mimeTypeDetection.ts
+++ b/packages/backend/src/util/mimeTypeDetection.ts
@@ -26,10 +26,10 @@ const genericMimeTypes = new Set([
  * @returns The best-guess MIME type
  */
 export function detectMimeType(
-  browserMimeType: string,
+  browserMimeType: string | undefined | null,
   filename: string
 ): string {
-  const normalizedBrowserMimeType = browserMimeType
+  const normalizedBrowserMimeType = (browserMimeType || "")
     .split(";")[0]
     .trim()
     .toLowerCase();


### PR DESCRIPTION
Files uploaded without an explicit multipart content type (e.g. via publish_badgehub.py) can land as a generic `text/plain` browser MIME type, which detectMimeType previously trusted as reliable and never fell back to the file extension. Public file routes also never set Content-Type and unconditionally forced Content-Disposition: attachment, so even correctly-typed images couldn't render inline.

Fixes #397