### PR TITLE
fix: exclude audio files from main executable selection

### DIFF
--- a/packages/frontend/src/pages/AppEditPage/FileListItem.test.tsx
+++ b/packages/frontend/src/pages/AppEditPage/FileListItem.test.tsx
@@ -64,6 +64,27 @@ describe("FileListItem", () => {
     expect(onSetMainExecutable).toHaveBeenCalledWith("main.py");
   });
 
+  it("does not offer Set as Main for audio files", () => {
+    const onSetMainExecutable = vi.fn();
+    const file = {
+      ...baseFile,
+      full_path: "theme.wav",
+      ext: "wav",
+      mimetype: "audio/wav",
+    };
+
+    render(
+      <FileListItem
+        file={file}
+        slug="demo"
+        keycloak={keycloak}
+        onSetMainExecutable={onSetMainExecutable}
+      />
+    );
+
+    expect(screen.queryByText("Set as Main")).not.toBeInTheDocument();
+  });
+
   it("shows and triggers icon action for image files", async () => {
     const user = userEvent.setup();
     const onSetIcon = vi.fn();

--- a/packages/frontend/src/pages/AppEditPage/FileListItem.tsx
+++ b/packages/frontend/src/pages/AppEditPage/FileListItem.tsx
@@ -48,8 +48,8 @@ export const FileListItem: React.FC<FileListItemProps> = ({
   const isSelectableAsMain =
     deletable &&
     onSetMainExecutable &&
-    !NON_EXECUTABLE_EXTENSIONS.some((ext) =>
-      file.full_path.toLowerCase().endsWith(ext)
+    !(NON_EXECUTABLE_EXTENSIONS as readonly string[]).includes(
+      `.${file.ext.toLowerCase()}`
     );
   const isCurrentMain = mainExecutable === file.full_path;
 

--- a/packages/frontend/src/pages/AppEditPage/FileListItem.tsx
+++ b/packages/frontend/src/pages/AppEditPage/FileListItem.tsx
@@ -2,7 +2,7 @@ import type { FileMetadata } from "@shared/domain/readModels/project/FileMetadat
 import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
 import { DeleteIcon } from "@sharedComponents/icons/DeleteIcon.tsx";
 import { downloadProjectFile } from "@utils/downloadProjectFile.ts";
-import { IMAGE_FILE_EXTENSIONS } from "@utils/fileUtils.ts";
+import { NON_EXECUTABLE_EXTENSIONS } from "@utils/fileUtils.ts";
 import type Keycloak from "keycloak-js";
 import type React from "react";
 
@@ -45,16 +45,10 @@ export const FileListItem: React.FC<FileListItemProps> = ({
   const showIconButton = onSetIcon && file.mimetype.startsWith("image/");
   const deletable = isDeletable(file);
 
-  const excludedExtensions = [
-    ...IMAGE_FILE_EXTENSIONS.map((ext) => `.${ext}`),
-    ".md",
-    ".txt",
-    ".json",
-  ];
   const isSelectableAsMain =
     deletable &&
     onSetMainExecutable &&
-    !excludedExtensions.some((ext) =>
+    !NON_EXECUTABLE_EXTENSIONS.some((ext) =>
       file.full_path.toLowerCase().endsWith(ext)
     );
   const isCurrentMain = mainExecutable === file.full_path;

--- a/packages/frontend/src/utils/fileUtils.ts
+++ b/packages/frontend/src/utils/fileUtils.ts
@@ -69,11 +69,8 @@ export const AUDIO_FILE_EXTENSIONS = [
 ] as const;
 
 export const NON_EXECUTABLE_EXTENSIONS = [
-  ".png",
-  ".jpg",
-  ".jpeg",
-  ".gif",
-  ".svg",
+  ...IMAGE_FILE_EXTENSIONS.map((ext) => `.${ext}`),
+  ...AUDIO_FILE_EXTENSIONS.map((ext) => `.${ext}`),
   ".md",
   ".txt",
   ".json",


### PR DESCRIPTION
## Summary
- `NON_EXECUTABLE_EXTENSIONS` (in `fileUtils.ts`) and a separate, duplicated exclusion list in `FileListItem.tsx` both predate the audio preview support added in #395, so neither ever excluded audio extensions.
- As a result, users could set a sound file (`.wav`, `.mp3`, etc.) as a project's main executable — both explicitly via the "Set as Main" button, and automatically on upload via `isExecutableFileName`.
- Fix: derive `NON_EXECUTABLE_EXTENSIONS` from `IMAGE_FILE_EXTENSIONS` + `AUDIO_FILE_EXTENSIONS` (plus `.md`/`.txt`/`.json`), and have `FileListItem` reuse that shared list (via `file.ext`, per review feedback) instead of maintaining its own copy, so the two can't drift apart again.

Closes #400

## Test plan
- [x] Added a regression test asserting audio files don't show a "Set as Main" button
- [x] Uploaded an audio file as the only file in a draft project and confirmed it is not auto-selected as the main executable
- [x] Confirmed image/`.md`/`.txt`/`.json` files still correctly show no "Set as Main" button (regression check)