### PR TITLE
fix: render already-parsed JSON bodies in published file preview

### DIFF
--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
@@ -34,6 +34,15 @@ vi.mock("@api/tsRestClient.ts", () => ({
           body: { name: "parsed", version: "2.0.0" },
         });
       }
+      if (params.filePath === "null.json") {
+        // A .json file whose content is the literal JSON value `null` is
+        // valid and should still render, not fall through to the
+        // "unable to display" message.
+        return Promise.resolve({
+          status: 200,
+          body: null,
+        });
+      }
       return Promise.resolve({
         status: 404,
         body: "File not found",
@@ -113,6 +122,19 @@ const mockProject: ProjectDetails = {
         size_formatted: "50 B",
         full_path: "parsed.json",
         url: "http://example.com/parsed.json",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "null",
+        ext: "json",
+        mimetype: "application/json",
+        size_of_content: 4,
+        sha256: "h".repeat(64),
+        size_formatted: "4 B",
+        full_path: "null.json",
+        url: "http://example.com/null.json",
         created_at: "2023-01-01T00:00:00Z",
         updated_at: "2023-01-01T00:00:00Z",
       },
@@ -265,6 +287,18 @@ describe("AppCodePreview", () => {
     fireEvent.click(screen.getByText("Pretty Print"));
     const prettyText = container.querySelector("pre")?.textContent ?? "";
     expect(prettyText).toMatch(/\n/);
+  });
+
+  it("renders a JSON file whose content is the literal value null", async () => {
+    const { container } = render(<AppCodePreview project={mockProject} />);
+
+    fireEvent.click(screen.getByText("null.json"));
+
+    expect(await screen.findByText("JSON file")).toBeInTheDocument();
+    expect(
+      screen.queryByText("// Unable to display file content")
+    ).not.toBeInTheDocument();
+    expect(container.querySelector("pre")?.textContent).toBe("null");
   });
 
   it("shows Python preview with syntax highlighting", async () => {

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
@@ -251,6 +251,22 @@ describe("AppCodePreview", () => {
     expect(screen.getByText('"2.0.0"')).toBeInTheDocument();
   });
 
+  it("pretty print actually reformats an already-parsed JSON body", async () => {
+    const { container } = render(<AppCodePreview project={mockProject} />);
+
+    fireEvent.click(screen.getByText("parsed.json"));
+    await screen.findByText("JSON file");
+
+    // Raw view should be compact (no line breaks), otherwise toggling to
+    // Pretty Print has nothing to actually change.
+    const rawText = container.querySelector("pre")?.textContent ?? "";
+    expect(rawText).not.toMatch(/\n/);
+
+    fireEvent.click(screen.getByText("Pretty Print"));
+    const prettyText = container.querySelector("pre")?.textContent ?? "";
+    expect(prettyText).toMatch(/\n/);
+  });
+
   it("shows Python preview with syntax highlighting", async () => {
     render(<AppCodePreview project={mockProject} />);
 

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.test.tsx
@@ -26,6 +26,14 @@ vi.mock("@api/tsRestClient.ts", () => ({
           body: "This is a simple text file.\nIt contains multiple lines.\nEach line is plain text.",
         });
       }
+      if (params.filePath === "parsed.json") {
+        // The real ts-rest client auto-parses application/json responses
+        // (see #398), so the body arrives as an object, not a string/Blob.
+        return Promise.resolve({
+          status: 200,
+          body: { name: "parsed", version: "2.0.0" },
+        });
+      }
       return Promise.resolve({
         status: 404,
         body: "File not found",
@@ -92,6 +100,19 @@ const mockProject: ProjectDetails = {
         size_formatted: "500 B",
         full_path: "readme.txt",
         url: "http://example.com/readme.txt",
+        created_at: "2023-01-01T00:00:00Z",
+        updated_at: "2023-01-01T00:00:00Z",
+      },
+      {
+        dir: "",
+        name: "parsed",
+        ext: "json",
+        mimetype: "application/json",
+        size_of_content: 50,
+        sha256: "g".repeat(64),
+        size_formatted: "50 B",
+        full_path: "parsed.json",
+        url: "http://example.com/parsed.json",
         created_at: "2023-01-01T00:00:00Z",
         updated_at: "2023-01-01T00:00:00Z",
       },
@@ -215,6 +236,19 @@ describe("AppCodePreview", () => {
     const prettyPrintButton = screen.getByText("Pretty Print");
     fireEvent.click(prettyPrintButton);
     expect(screen.getByText("Show Raw")).toBeInTheDocument();
+  });
+
+  it("shows JSON preview when the client returns an already-parsed body", async () => {
+    render(<AppCodePreview project={mockProject} />);
+
+    fireEvent.click(screen.getByText("parsed.json"));
+
+    expect(await screen.findByText("JSON file")).toBeInTheDocument();
+    expect(
+      screen.queryByText("// Unable to display file content")
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('"parsed"')).toBeInTheDocument();
+    expect(screen.getByText('"2.0.0"')).toBeInTheDocument();
   });
 
   it("shows Python preview with syntax highlighting", async () => {

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -461,7 +461,7 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
               const text = await res.body.text();
               setFileContent(text);
               setPreviewBlob(null);
-            } else if (res.body != null) {
+            } else if (res.body !== undefined) {
               // The ts-rest client auto-parses JSON responses (e.g. for
               // .json files, which now get a proper Content-Type per #398),
               // so the body arrives already parsed rather than as text/Blob.

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -461,6 +461,12 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
               const text = await res.body.text();
               setFileContent(text);
               setPreviewBlob(null);
+            } else if (res.body != null) {
+              // The ts-rest client auto-parses JSON responses (e.g. for
+              // .json files, which now get a proper Content-Type per #398),
+              // so the body arrives already parsed rather than as text/Blob.
+              setFileContent(JSON.stringify(res.body, null, 2));
+              setPreviewBlob(null);
             } else {
               setFileContent("// Unable to display file content");
               setPreviewBlob(null);

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -465,7 +465,9 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
               // The ts-rest client auto-parses JSON responses (e.g. for
               // .json files, which now get a proper Content-Type per #398),
               // so the body arrives already parsed rather than as text/Blob.
-              setFileContent(JSON.stringify(res.body, null, 2));
+              // Stringify compactly (no indent) so JsonPreview's raw/pretty
+              // toggle still has an actual formatting difference to show.
+              setFileContent(JSON.stringify(res.body));
               setPreviewBlob(null);
             } else {
               setFileContent("// Unable to display file content");


### PR DESCRIPTION
## Summary
- #398 correctly added `Content-Type: application/json` for public file routes, but the ts-rest client (`@ts-rest/core`'s `tsRestFetchApi`) auto-parses `application/json` responses into an object instead of returning text/Blob.
- The published-mode file preview (`AppCodePreview.tsx`) only handled `string` and `Blob` bodies, so viewing a `.json` file on a project's public detail page fell through to `"// Unable to display file content"` instead of showing the JSON.
- Draft-mode preview (`getDraftFile`) is unaffected — it never sets a `Content-Type`, so it still returns a `Blob`.
- Stringifies the already-parsed body back to text, compactly (no indentation) rather than pretty-printed, since `JsonPreview`'s raw/pretty toggle needs the raw view to actually differ from the pretty view — an earlier version of this fix pretty-printed the raw content too, silently breaking the toggle.
- Checks `res.body !== undefined` rather than `!= null`, since a `.json` file whose content is the literal value `null` is valid JSON and shouldn't be treated as absent (per review feedback).

Closes #402

## Test plan
- [x] Added a regression test asserting the JSON preview renders content (not the fallback message) when the client returns an already-parsed body
- [x] Added a regression test asserting the Pretty Print toggle actually reformats the content (raw has no line breaks, pretty does)
- [x] Added a regression test for a JSON file whose content is the literal value `null`
- [x] Full frontend test suite passes