### PR TITLE
fix: use extraHeaders instead of headers in useUserDraftProjectsFetcher

### DIFF
--- a/packages/frontend/src/hooks/useUserDraftProjectsFetcher.ts
+++ b/packages/frontend/src/hooks/useUserDraftProjectsFetcher.ts
@@ -33,7 +33,7 @@ export const useUserDraftProjectsFetcher = ({
         params: {
           userId: user.id,
         },
-        headers: {
+        extraHeaders: {
           authorization: `Bearer ${keycloak.token}`,
         },
       })


### PR DESCRIPTION
## Summary
- `a64778a` moved `getUserDraftProjects` into a router with a strict `baseHeaders` schema, which changed the generated client call type to only accept `extraHeaders`, not `headers`.
- This broke `check:ts` on `main` (and any PR branched from it) with: `Object literal may only specify known properties, and 'headers' does not exist in type '...'`.
- `extraHeaders` and `headers` are merged identically at the ts-rest client runtime level (`headers: {...extraHeaders, ...headers}` in `@ts-rest/core`), so this is a type-only fix with no behavior change.
- Confirmed this was the only affected call site: grepped the frontend for other `headers: {` usages (the only other match is an unrelated native `fetch()` call in `AppCard.tsx`), and confirmed `createProject` (also moved under the new `baseHeaders` contract) is called via `getFreshAuthorizedTsRestClient`, which attaches auth at the client level, not per-call.

Closes #404

## Test plan
- [x] `npm run check:ts --workspaces` passes cleanly (was failing before this fix)
- [x] Full frontend test suite passes (no behavior change, ts-rest core merges extraHeaders/headers identically at runtime)