### PR TITLE
Add Markdown support for long project descriptions

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -21,4 +21,4 @@ jobs:
       - run: pnpm install --frozen-lockfile 2>&1 | tee install.log
       - run: pnpm peers check
       - name: No deprecated packages
-        run: '! grep -qi deprecated install.log'
+        run: '! grep -Eqi "WARN.*deprecated" install.log'

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -21,4 +21,4 @@ jobs:
       - run: pnpm install --frozen-lockfile 2>&1 | tee install.log
       - run: pnpm peers check
       - name: No deprecated packages
-        run: '! grep -Eqi "WARN.*deprecated" install.log'
+        run: '! grep -Eq "WARN.*deprecated" install.log'

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,7 +11,6 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@uiw/react-md-editor": "^4.0.8",
     "keycloak-js": "^26.2.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@uiw/react-md-editor": "^4.0.8",
     "keycloak-js": "^26.2.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
     "keycloak-js": "^26.2.4",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.18.1",
     "react-syntax-highlighter": "^15.6.6",
     "shared": "workspace:*",

--- a/packages/frontend/src/hooks/useIsDarkTheme.ts
+++ b/packages/frontend/src/hooks/useIsDarkTheme.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+
+export function useIsDarkTheme() {
+  const [isDark, setIsDark] = useState(
+    () => getComputedStyle(document.documentElement).colorScheme === "dark"
+  );
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      setIsDark(
+        getComputedStyle(document.documentElement).colorScheme === "dark"
+      );
+    });
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+    return () => observer.disconnect();
+  }, []);
+  return isDark;
+}

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -5,14 +5,9 @@ import {
 import type { FileMetadata } from "@shared/domain/readModels/project/FileMetadata.ts";
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
 import { assertDefined } from "@shared/util/assertions.ts";
-import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
+import CodeBlock from "@sharedComponents/CodeBlock.tsx";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import {
-  atomOneDark,
-  atomOneLight,
-} from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import { downloadProjectFile } from "@utils/downloadProjectFile.ts";
 import { getLanguageFromFile, getPreviewType } from "@utils/filePreview.ts";
 import type Keycloak from "keycloak-js";
@@ -37,10 +32,7 @@ const DownloadIcon = () => (
 );
 
 // JSON Preview Component with pretty print option and syntax highlighting
-const JsonPreview: React.FC<{ content: string; isDark: boolean }> = ({
-  content,
-  isDark,
-}) => {
+const JsonPreview: React.FC<{ content: string }> = ({ content }) => {
   const [isPretty, setIsPretty] = useState(false);
 
   const formatJson = (jsonStr: string): string => {
@@ -67,64 +59,28 @@ const JsonPreview: React.FC<{ content: string; isDark: boolean }> = ({
           {isPretty ? "Show Raw" : "Pretty Print"}
         </button>
       </div>
-      <div className="rounded overflow-hidden">
-        <SyntaxHighlighter
-          language="json"
-          style={isDark ? atomOneDark : atomOneLight}
-          customStyle={{
-            padding: "1rem",
-            margin: 0,
-            fontSize: "0.875rem",
-            lineHeight: "1.25rem",
-          }}
-          showLineNumbers={false}
-          wrapLines={true}
-          wrapLongLines={true}
-        >
-          {displayContent}
-        </SyntaxHighlighter>
-      </div>
+      <CodeBlock language="json">{displayContent}</CodeBlock>
     </div>
   );
 };
 
 // Python Preview Component with syntax highlighting
-const PythonPreview: React.FC<{ content: string; isDark: boolean }> = ({
-  content,
-  isDark,
-}) => {
+const PythonPreview: React.FC<{ content: string }> = ({ content }) => {
   return (
     <div>
       <div className="mb-2">
         <span className="text-base-content/80 text-sm">Python file</span>
       </div>
-      <div className="rounded overflow-hidden">
-        <SyntaxHighlighter
-          language="python"
-          style={isDark ? atomOneDark : atomOneLight}
-          customStyle={{
-            padding: "1rem",
-            margin: 0,
-            fontSize: "0.875rem",
-            lineHeight: "1.25rem",
-          }}
-          showLineNumbers={false}
-          wrapLines={true}
-          wrapLongLines={true}
-        >
-          {content}
-        </SyntaxHighlighter>
-      </div>
+      <CodeBlock language="python">{content}</CodeBlock>
     </div>
   );
 };
 
 // Text Preview Component with syntax highlighting for recognized file types
-const TextPreview: React.FC<{
-  content: string;
-  filename: string;
-  isDark: boolean;
-}> = ({ content, filename, isDark }) => {
+const TextPreview: React.FC<{ content: string; filename: string }> = ({
+  content,
+  filename,
+}) => {
   const language = getLanguageFromFile(filename);
 
   if (language === "text") {
@@ -147,23 +103,7 @@ const TextPreview: React.FC<{
       <div className="mb-2">
         <span className="text-base-content/80 text-sm">{language} file</span>
       </div>
-      <div className="rounded overflow-hidden">
-        <SyntaxHighlighter
-          language={language}
-          style={isDark ? atomOneDark : atomOneLight}
-          customStyle={{
-            padding: "1rem",
-            margin: 0,
-            fontSize: "0.875rem",
-            lineHeight: "1.25rem",
-          }}
-          showLineNumbers={false}
-          wrapLines={true}
-          wrapLongLines={true}
-        >
-          {content}
-        </SyntaxHighlighter>
-      </div>
+      <CodeBlock language={language}>{content}</CodeBlock>
     </div>
   );
 };
@@ -256,7 +196,6 @@ const renderFilePreview = (
   previewedFile: string | null,
   currentFile: FileMetadata | null,
   fileContent: string | null,
-  isDark: boolean,
   previewBlob?: Blob
 ): React.ReactElement => {
   if (loading) {
@@ -283,23 +222,19 @@ const renderFilePreview = (
       return <AudioPreview file={currentFile} audioBlob={previewBlob} />;
     case "json":
       return fileContent ? (
-        <JsonPreview content={fileContent} isDark={isDark} />
+        <JsonPreview content={fileContent} />
       ) : (
         <div className="opacity-60">Loading JSON...</div>
       );
     case "python":
       return fileContent ? (
-        <PythonPreview content={fileContent} isDark={isDark} />
+        <PythonPreview content={fileContent} />
       ) : (
         <div className="opacity-60">Loading Python file...</div>
       );
     case "text":
       return fileContent ? (
-        <TextPreview
-          content={fileContent}
-          filename={currentFile.full_path}
-          isDark={isDark}
-        />
+        <TextPreview content={fileContent} filename={currentFile.full_path} />
       ) : (
         <div className="opacity-60">Loading text file...</div>
       );
@@ -329,7 +264,6 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
     () => project?.version?.files ?? [],
     [project?.version?.files]
   );
-  const isDark = useIsDarkTheme();
   const [previewedFile, setPreviewedFile] = useState<string | null>(null);
   const [fileContent, setFileContent] = useState<string | null>(null);
   const [previewBlob, setPreviewBlob] = useState<Blob | null>(null);
@@ -565,7 +499,6 @@ const AppCodePreview: React.FC<AppCodePreviewProps> = ({
               previewedFile,
               currentFile,
               fileContent,
-              isDark,
               previewBlob || undefined
             )}
           </div>

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -6,11 +6,11 @@ import type { FileMetadata } from "@shared/domain/readModels/project/FileMetadat
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
 import { assertDefined } from "@shared/util/assertions.ts";
 import CodeBlock from "@sharedComponents/CodeBlock.tsx";
-import type React from "react";
-import { useEffect, useMemo, useState } from "react";
 import { downloadProjectFile } from "@utils/downloadProjectFile.ts";
 import { getLanguageFromFile, getPreviewType } from "@utils/filePreview.ts";
 import type Keycloak from "keycloak-js";
+import type React from "react";
+import { useEffect, useMemo, useState } from "react";
 
 const DownloadIcon = () => (
   <svg

--- a/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppCodePreview.tsx
@@ -5,6 +5,7 @@ import {
 import type { FileMetadata } from "@shared/domain/readModels/project/FileMetadata.ts";
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
 import { assertDefined } from "@shared/util/assertions.ts";
+import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
@@ -12,26 +13,6 @@ import {
   atomOneDark,
   atomOneLight,
 } from "react-syntax-highlighter/dist/cjs/styles/hljs";
-
-function useIsDarkTheme() {
-  const [isDark, setIsDark] = useState(
-    () => getComputedStyle(document.documentElement).colorScheme === "dark"
-  );
-  useEffect(() => {
-    const observer = new MutationObserver(() => {
-      setIsDark(
-        getComputedStyle(document.documentElement).colorScheme === "dark"
-      );
-    });
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ["data-theme"],
-    });
-    return () => observer.disconnect();
-  }, []);
-  return isDark;
-}
-
 import { downloadProjectFile } from "@utils/downloadProjectFile.ts";
 import { getLanguageFromFile, getPreviewType } from "@utils/filePreview.ts";
 import type Keycloak from "keycloak-js";

--- a/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
@@ -9,15 +9,15 @@ const AppDescription: React.FC<{ project: ProjectDetails }> = ({
 }) => {
   const longDescription = app_metadata.long_description?.trim();
   const shortDescription = app_metadata.description?.trim();
-  const primaryDescription = longDescription || shortDescription;
-
   return (
     <section className="card bg-base-200 shadow-lg">
       <div className="card-body">
         <h2 className="card-title text-2xl mb-4">Description</h2>
         <div className="prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none text-base-content/80 space-y-4">
-          {primaryDescription ? (
-            <MarkdownText>{primaryDescription}</MarkdownText>
+          {longDescription ? (
+            <MarkdownText>{longDescription}</MarkdownText>
+          ) : shortDescription ? (
+            <p className="whitespace-pre-wrap">{shortDescription}</p>
           ) : (
             <p>No description provided.</p>
           )}

--- a/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
@@ -13,7 +13,7 @@ const AppDescription: React.FC<{ project: ProjectDetails }> = ({
     <section className="card bg-base-200 shadow-lg">
       <div className="card-body">
         <h2 className="card-title text-2xl mb-4">Description</h2>
-        <div className="prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none text-base-content/80 space-y-4">
+        <div className="max-w-none text-base-content/80 space-y-4">
           {longDescription ? (
             <MarkdownText>{longDescription}</MarkdownText>
           ) : shortDescription ? (

--- a/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDescription.tsx
@@ -1,4 +1,5 @@
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
+import MarkdownText from "@sharedComponents/MarkdownText.tsx";
 import type React from "react";
 
 const AppDescription: React.FC<{ project: ProjectDetails }> = ({
@@ -16,7 +17,7 @@ const AppDescription: React.FC<{ project: ProjectDetails }> = ({
         <h2 className="card-title text-2xl mb-4">Description</h2>
         <div className="prose prose-sm sm:prose lg:prose-lg xl:prose-xl max-w-none text-base-content/80 space-y-4">
           {primaryDescription ? (
-            <p className="whitespace-pre-wrap">{primaryDescription}</p>
+            <MarkdownText>{primaryDescription}</MarkdownText>
           ) : (
             <p>No description provided.</p>
           )}

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
@@ -62,7 +62,11 @@ describe("AppDetailPage", { timeout: 1000_000 }, () => {
   });
 
   it("renders the long description as Markdown", async () => {
-    const firstApp = dummyApps[0]!;
+    const firstApp = dummyApps[0];
+    expect(firstApp).toBeDefined();
+    if (!firstApp) {
+      throw new Error("Expected a dummy app");
+    }
     const appsWithMarkdown = [
       {
         ...firstApp,

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
@@ -61,6 +61,38 @@ describe("AppDetailPage", { timeout: 1000_000 }, () => {
     expect(await screen.findByText(app.description)).toBeInTheDocument();
   });
 
+  it("renders the long description as Markdown", async () => {
+    const firstApp = dummyApps[0]!;
+    const appsWithMarkdown = [
+      {
+        ...firstApp,
+        details: {
+          ...firstApp.details,
+          version: {
+            ...firstApp.details.version,
+            app_metadata: {
+              ...firstApp.details.version.app_metadata,
+              long_description: "## Features\n\n- Offline support",
+            },
+          },
+        },
+      },
+      ...dummyApps.slice(1),
+    ];
+
+    render(
+      <AppDetailPage
+        tsRestClient={tsRestClientWithApps(appsWithMarkdown)}
+        slug="dummy-app-1"
+      />
+    );
+
+    expect(
+      await screen.findByRole("heading", { level: 2, name: "Features" })
+    ).toBeInTheDocument();
+    expect(screen.getByText("Offline support").tagName).toBe("LI");
+  });
+
   it("renders the app revision", async () => {
     const app = dummyApps[0]?.summary;
     expect(app).toBeDefined();

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.test.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.test.tsx
@@ -30,6 +30,20 @@ describe("AppEditBasicInfo", () => {
     expect(screen.getByLabelText(/hidden/i)).not.toBeChecked();
   });
 
+  it("previews the long description as Markdown", () => {
+    render(
+      <AppEditBasicInfo
+        form={{ ...baseForm, long_description: "## Preview heading" }}
+        onChange={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { level: 2, name: "Preview heading" })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/18 characters/)).toBeInTheDocument();
+  });
+
   it("calls onChange for updated fields", async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -84,7 +84,7 @@ const AppEditBasicInfo: React.FC<{
             </label>
             <textarea
               id="description"
-              rows={4}
+              rows={2}
               className="textarea textarea-bordered w-full"
               value={form.description || ""}
               onChange={(e) => onChange({ description: e.target.value })}

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -100,8 +100,12 @@ const AppEditBasicInfo: React.FC<{
 
             <div className="form-control">
               <div className="label">
-                <span className="label-text">Long Description</span>
-                <span className="label-text-alt">Markdown supported</span>
+                <label htmlFor="longDescription" className="label-text">
+                  Long Description
+                </label>
+                <span className="label-text-alt">
+                  Markdown · {form.long_description?.length || 0}/2000
+                </span>
               </div>
               <div data-color-mode="dark">
                 <MDEditor
@@ -114,6 +118,7 @@ const AppEditBasicInfo: React.FC<{
                     id: "longDescription",
                     placeholder:
                       "Enter a long description using Markdown formatting.",
+                    maxLength: 2000,
                   }}
                   height={300}
                 />

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -118,7 +118,7 @@ const AppEditBasicInfo: React.FC<{
                   onChange({ long_description: event.target.value })
                 }
               />
-              <div className="rounded-box border border-base-300 bg-base-100 p-4">
+              <div className="rounded-box border border-base-300 bg-base-100 p-4 max-h-96 overflow-y-auto">
                 <p className="mb-3 text-xs font-semibold uppercase tracking-wide opacity-60">
                   Preview
                 </p>

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -77,39 +77,40 @@ const AppEditBasicInfo: React.FC<{
             />
           </div>
 
-          {/* Description */}
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div className="form-control">
-              <label htmlFor="description" className="label">
-                <span className="label-text">Short Description</span>
-              </label>
-              <textarea
-                id="description"
-                rows={4}
-                className="textarea textarea-bordered w-full"
-                value={form.description || ""}
-                onChange={(e) => onChange({ description: e.target.value })}
-              />
-              <div className="label">
-                <span className="label-text-alt whitespace-normal break-words">
-                  Used where space is limited. Hidden on the detail page when a
-                  long description is provided.
-                </span>
-              </div>
+          {/* Short Description */}
+          <div className="form-control">
+            <label htmlFor="description" className="label">
+              <span className="label-text">Short Description</span>
+            </label>
+            <textarea
+              id="description"
+              rows={4}
+              className="textarea textarea-bordered w-full"
+              value={form.description || ""}
+              onChange={(e) => onChange({ description: e.target.value })}
+            />
+            <div className="label">
+              <span className="label-text-alt whitespace-normal break-words">
+                Used where space is limited. Hidden on the detail page when a
+                long description is provided.
+              </span>
             </div>
+          </div>
 
-            <div className="form-control">
-              <div className="label">
-                <label htmlFor="longDescription" className="label-text">
-                  Long Description
-                </label>
-                <span className="label-text-alt">
-                  Markdown · {form.long_description?.length || 0} characters
-                </span>
-              </div>
+          {/* Long Description */}
+          <div className="form-control">
+            <div className="label">
+              <label htmlFor="longDescription" className="label-text">
+                Long Description
+              </label>
+              <span className="label-text-alt">
+                Markdown · {form.long_description?.length || 0} characters
+              </span>
+            </div>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <textarea
                 id="longDescription"
-                rows={8}
+                rows={16}
                 className="textarea textarea-bordered w-full font-mono"
                 value={form.long_description || ""}
                 placeholder="Enter a long description using Markdown formatting."
@@ -117,20 +118,24 @@ const AppEditBasicInfo: React.FC<{
                   onChange({ long_description: event.target.value })
                 }
               />
-              {form.long_description?.trim() && (
-                <div className="mt-3 rounded-box border border-base-300 bg-base-100 p-4">
-                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide opacity-60">
-                    Preview
-                  </p>
+              <div className="rounded-box border border-base-300 bg-base-100 p-4">
+                <p className="mb-3 text-xs font-semibold uppercase tracking-wide opacity-60">
+                  Preview
+                </p>
+                {form.long_description?.trim() ? (
                   <MarkdownText>{form.long_description}</MarkdownText>
-                </div>
-              )}
-              <div className="label">
-                <span className="label-text-alt whitespace-normal break-words">
-                  Preferred on the detail page and other layouts with enough
-                  room. Falls back to the short description when empty.
-                </span>
+                ) : (
+                  <p className="text-sm opacity-60">
+                    Nothing to preview yet.
+                  </p>
+                )}
               </div>
+            </div>
+            <div className="label">
+              <span className="label-text-alt whitespace-normal break-words">
+                Preferred on the detail page and other layouts with enough
+                room. Falls back to the short description when empty.
+              </span>
             </div>
           </div>
 

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -125,16 +125,14 @@ const AppEditBasicInfo: React.FC<{
                 {form.long_description?.trim() ? (
                   <MarkdownText>{form.long_description}</MarkdownText>
                 ) : (
-                  <p className="text-sm opacity-60">
-                    Nothing to preview yet.
-                  </p>
+                  <p className="text-sm opacity-60">Nothing to preview yet.</p>
                 )}
               </div>
             </div>
             <div className="label">
               <span className="label-text-alt whitespace-normal break-words">
-                Preferred on the detail page and other layouts with enough
-                room. Falls back to the short description when empty.
+                Preferred on the detail page and other layouts with enough room.
+                Falls back to the short description when empty.
               </span>
             </div>
           </div>

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -1,6 +1,8 @@
 import type { ProjectEditFormData } from "@pages/AppEditPage/ProjectEditFormData.ts";
 import GitLink from "@sharedComponents/GitLink.tsx";
+import MarkdownText from "@sharedComponents/MarkdownText.tsx";
 import type React from "react";
+import { useState } from "react";
 
 /**
  * A component for editing the basic information of an application.
@@ -11,6 +13,7 @@ const AppEditBasicInfo: React.FC<{
   form: ProjectEditFormData;
   onChange: (changes: Partial<ProjectEditFormData>) => void;
 }> = ({ form, onChange }) => {
+  const [activeTab, setActiveTab] = useState<"write" | "preview">("write");
   return (
     <section className="card bg-base-200 shadow-lg">
       <div className="card-body">
@@ -98,16 +101,49 @@ const AppEditBasicInfo: React.FC<{
             </div>
 
             <div className="form-control">
-              <label htmlFor="longDescription" className="label">
+              <div className="label">
                 <span className="label-text">Long Description</span>
-              </label>
-              <textarea
-                id="longDescription"
-                rows={4}
-                className="textarea textarea-bordered w-full"
-                value={form.long_description || ""}
-                onChange={(e) => onChange({ long_description: e.target.value })}
-              />
+                <span className="label-text-alt">Markdown supported</span>
+              </div>
+              <div role="tablist" className="tabs tabs-border mb-2">
+                <button
+                  type="button"
+                  role="tab"
+                  onClick={() => setActiveTab("write")}
+                  className={`tab ${activeTab === "write" ? "tab-active" : ""}`}
+                >
+                  Write
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  onClick={() => setActiveTab("preview")}
+                  className={`tab ${activeTab === "preview" ? "tab-active" : ""}`}
+                >
+                  Preview
+                </button>
+              </div>
+              {activeTab === "write" ? (
+                <textarea
+                  id="longDescription"
+                  rows={4}
+                  className="textarea textarea-bordered w-full font-mono"
+                  value={form.long_description || ""}
+                  onChange={(e) =>
+                    onChange({ long_description: e.target.value })
+                  }
+                />
+              ) : (
+                <div className="min-h-28 rounded-box border border-base-300 p-3">
+                  {form.long_description ? (
+                    <MarkdownText>{form.long_description}</MarkdownText>
+                  ) : (
+                    <p className="opacity-60 italic">
+                      No long description provided.
+                    </p>
+                  )}
+                </div>
+              )}
               <div className="label">
                 <span className="label-text-alt whitespace-normal break-words">
                   Preferred on the detail page and other layouts with enough

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -1,6 +1,6 @@
 import type { ProjectEditFormData } from "@pages/AppEditPage/ProjectEditFormData.ts";
 import GitLink from "@sharedComponents/GitLink.tsx";
-import MDEditor from "@uiw/react-md-editor";
+import MarkdownText from "@sharedComponents/MarkdownText.tsx";
 import type React from "react";
 
 /**
@@ -104,25 +104,27 @@ const AppEditBasicInfo: React.FC<{
                   Long Description
                 </label>
                 <span className="label-text-alt">
-                  Markdown · {form.long_description?.length || 0}/2000
+                  Markdown · {form.long_description?.length || 0} characters
                 </span>
               </div>
-              <div data-color-mode="dark">
-                <MDEditor
-                  value={form.long_description || ""}
-                  onChange={(value) =>
-                    onChange({ long_description: value || "" })
-                  }
-                  visibleDragbar={false}
-                  textareaProps={{
-                    id: "longDescription",
-                    placeholder:
-                      "Enter a long description using Markdown formatting.",
-                    maxLength: 2000,
-                  }}
-                  height={300}
-                />
-              </div>
+              <textarea
+                id="longDescription"
+                rows={8}
+                className="textarea textarea-bordered w-full font-mono"
+                value={form.long_description || ""}
+                placeholder="Enter a long description using Markdown formatting."
+                onChange={(event) =>
+                  onChange({ long_description: event.target.value })
+                }
+              />
+              {form.long_description?.trim() && (
+                <div className="mt-3 rounded-box border border-base-300 bg-base-100 p-4">
+                  <p className="mb-3 text-xs font-semibold uppercase tracking-wide opacity-60">
+                    Preview
+                  </p>
+                  <MarkdownText>{form.long_description}</MarkdownText>
+                </div>
+              )}
               <div className="label">
                 <span className="label-text-alt whitespace-normal break-words">
                   Preferred on the detail page and other layouts with enough

--- a/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditBasicInfo.tsx
@@ -1,8 +1,7 @@
 import type { ProjectEditFormData } from "@pages/AppEditPage/ProjectEditFormData.ts";
 import GitLink from "@sharedComponents/GitLink.tsx";
-import MarkdownText from "@sharedComponents/MarkdownText.tsx";
+import MDEditor from "@uiw/react-md-editor";
 import type React from "react";
-import { useState } from "react";
 
 /**
  * A component for editing the basic information of an application.
@@ -13,7 +12,6 @@ const AppEditBasicInfo: React.FC<{
   form: ProjectEditFormData;
   onChange: (changes: Partial<ProjectEditFormData>) => void;
 }> = ({ form, onChange }) => {
-  const [activeTab, setActiveTab] = useState<"write" | "preview">("write");
   return (
     <section className="card bg-base-200 shadow-lg">
       <div className="card-body">
@@ -105,45 +103,21 @@ const AppEditBasicInfo: React.FC<{
                 <span className="label-text">Long Description</span>
                 <span className="label-text-alt">Markdown supported</span>
               </div>
-              <div role="tablist" className="tabs tabs-border mb-2">
-                <button
-                  type="button"
-                  role="tab"
-                  onClick={() => setActiveTab("write")}
-                  className={`tab ${activeTab === "write" ? "tab-active" : ""}`}
-                >
-                  Write
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  onClick={() => setActiveTab("preview")}
-                  className={`tab ${activeTab === "preview" ? "tab-active" : ""}`}
-                >
-                  Preview
-                </button>
-              </div>
-              {activeTab === "write" ? (
-                <textarea
-                  id="longDescription"
-                  rows={4}
-                  className="textarea textarea-bordered w-full font-mono"
+              <div data-color-mode="dark">
+                <MDEditor
                   value={form.long_description || ""}
-                  onChange={(e) =>
-                    onChange({ long_description: e.target.value })
+                  onChange={(value) =>
+                    onChange({ long_description: value || "" })
                   }
+                  visibleDragbar={false}
+                  textareaProps={{
+                    id: "longDescription",
+                    placeholder:
+                      "Enter a long description using Markdown formatting.",
+                  }}
+                  height={300}
                 />
-              ) : (
-                <div className="min-h-28 rounded-box border border-base-300 p-3">
-                  {form.long_description ? (
-                    <MarkdownText>{form.long_description}</MarkdownText>
-                  ) : (
-                    <p className="opacity-60 italic">
-                      No long description provided.
-                    </p>
-                  )}
-                </div>
-              )}
+              </div>
               <div className="label">
                 <span className="label-text-alt whitespace-normal break-words">
                   Preferred on the detail page and other layouts with enough

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -2,7 +2,6 @@ import { ERROR_ICON_URL, FALLBACK_ICON_URL } from "@config.ts";
 import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
 import GitLink from "@sharedComponents/GitLink.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
-import MarkdownText from "@sharedComponents/MarkdownText.tsx";
 import { MLink } from "@sharedComponents/MLink.tsx";
 import type React from "react";
 import { useEffect, useState } from "react";
@@ -130,14 +129,9 @@ const AppCard: React.FC<
         </div>
 
         {/* Description with line clamp */}
-        {description && (
-          <MarkdownText
-            plainText
-            className="text-sm opacity-70 leading-relaxed line-clamp-2"
-          >
-            {description}
-          </MarkdownText>
-        )}
+        <p className="text-sm opacity-70 leading-relaxed line-clamp-2">
+          {description}
+        </p>
 
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">
@@ -164,9 +158,7 @@ const AppCard: React.FC<
                   <span
                     key={tag.id}
                     className={`${
-                      tag.type === "category"
-                        ? "badge badge-neutral"
-                        : "badge badge-success"
+                      tag.type === "category" ? "badge badge-neutral" : "badge badge-success"
                     } text-xs font-semibold mr-2`}
                   >
                     {tag.text}

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -2,6 +2,7 @@ import { ERROR_ICON_URL, FALLBACK_ICON_URL } from "@config.ts";
 import { DownloadIcon } from "@sharedComponents/AppsGrid/DownloadIcon.tsx";
 import GitLink from "@sharedComponents/GitLink.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
+import MarkdownText from "@sharedComponents/MarkdownText.tsx";
 import { MLink } from "@sharedComponents/MLink.tsx";
 import type React from "react";
 import { useEffect, useState } from "react";
@@ -129,9 +130,14 @@ const AppCard: React.FC<
         </div>
 
         {/* Description with line clamp */}
-        <p className="text-sm opacity-70 leading-relaxed line-clamp-2">
-          {description}
-        </p>
+        {description && (
+          <MarkdownText
+            plainText
+            className="text-sm opacity-70 leading-relaxed line-clamp-2"
+          >
+            {description}
+          </MarkdownText>
+        )}
 
         {/* Tags section pushed to bottom */}
         <div className="mt-auto mb-3">

--- a/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
+++ b/packages/frontend/src/sharedComponents/AppsGrid/AppCard.tsx
@@ -158,7 +158,9 @@ const AppCard: React.FC<
                   <span
                     key={tag.id}
                     className={`${
-                      tag.type === "category" ? "badge badge-neutral" : "badge badge-success"
+                      tag.type === "category"
+                        ? "badge badge-neutral"
+                        : "badge badge-success"
                     } text-xs font-semibold mr-2`}
                   >
                     {tag.text}

--- a/packages/frontend/src/sharedComponents/CodeBlock.tsx
+++ b/packages/frontend/src/sharedComponents/CodeBlock.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { atomOneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
+
+interface CodeBlockProps {
+  children: string;
+  language?: string;
+  wrapperClassName?: string;
+}
+
+const CodeBlock: React.FC<CodeBlockProps> = ({
+  children,
+  language,
+  wrapperClassName = "rounded overflow-hidden",
+}) => {
+  const isDark = useIsDarkTheme();
+  return (
+    <div className={wrapperClassName}>
+      <SyntaxHighlighter
+        language={language}
+        style={isDark ? atomOneDark : atomOneLight}
+        customStyle={{
+          margin: 0,
+          padding: "1rem",
+          fontSize: "0.875rem",
+          lineHeight: "1.25rem",
+        }}
+        showLineNumbers={false}
+        wrapLines={true}
+        wrapLongLines={true}
+      >
+        {children}
+      </SyntaxHighlighter>
+    </div>
+  );
+};
+
+export default CodeBlock;

--- a/packages/frontend/src/sharedComponents/CodeBlock.tsx
+++ b/packages/frontend/src/sharedComponents/CodeBlock.tsx
@@ -1,8 +1,10 @@
-import React from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import { atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs";
-import { atomOneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs";
 import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
+import type React from "react";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import {
+  atomOneDark,
+  atomOneLight,
+} from "react-syntax-highlighter/dist/cjs/styles/hljs";
 
 interface CodeBlockProps {
   children: string;

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import MarkdownText from "./MarkdownText";
+
+describe("MarkdownText", () => {
+  it("renders markdown content as HTML", () => {
+    const markdownContent = "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
+    
+    render(
+      <MarkdownText>
+        {markdownContent}
+      </MarkdownText>
+    );
+
+    // Check that markdown is rendered as HTML
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Hello World");
+    expect(screen.getByText("bold")).toBeInTheDocument();
+    expect(screen.getByText("italic")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute("href", "https://example.com");
+  });
+
+  it("strips markdown when plainText is true", () => {
+    const markdownContent = "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
+    
+    render(
+      <MarkdownText plainText>
+        {markdownContent}
+      </MarkdownText>
+    );
+
+    // Check that markdown is stripped and rendered as plain text
+    const textContent = screen.getByText(/Hello World.*bold.*italic.*link/);
+    expect(textContent).toBeInTheDocument();
+    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("handles empty content gracefully", () => {
+    const { container } = render(
+      <MarkdownText>
+        {""}
+      </MarkdownText>
+    );
+
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <MarkdownText className="custom-class">
+        {"Test content"}
+      </MarkdownText>
+    );
+
+    expect(container.firstChild).toHaveClass("custom-class");
+  });
+});

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -33,6 +33,29 @@ describe("MarkdownText", () => {
     expect(screen.getByText(/script.*unsafe.*script/i)).toBeInTheDocument();
   });
 
+  it("uses standard Markdown wrapping for soft line breaks", () => {
+    const { container } = render(
+      <MarkdownText>{"First line\nsecond line"}</MarkdownText>
+    );
+
+    expect(container.querySelector("p")).not.toHaveClass("whitespace-pre-wrap");
+    expect(screen.getByText(/First line\s+second line/)).toBeInTheDocument();
+  });
+
+  it("resets inline code decoration inside fenced code blocks", () => {
+    const { container } = render(
+      <MarkdownText>{"```ts\nconst ready = true;\n```"}</MarkdownText>
+    );
+    const codeBlock = container.querySelector("pre");
+
+    expect(codeBlock).toHaveClass(
+      "[&_code]:rounded-none",
+      "[&_code]:bg-transparent",
+      "[&_code]:p-0"
+    );
+    expect(codeBlock?.querySelector("code")).toBeInTheDocument();
+  });
+
   it("handles empty content gracefully", () => {
     const { container } = render(<MarkdownText>{""}</MarkdownText>);
 

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -9,7 +9,6 @@ describe("MarkdownText", () => {
 
     render(<MarkdownText>{markdownContent}</MarkdownText>);
 
-    // Check that markdown is rendered as HTML
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
       "Hello World"
     );
@@ -19,19 +18,19 @@ describe("MarkdownText", () => {
       "href",
       "https://example.com"
     );
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
+      "target",
+      "_blank"
+    );
   });
 
-  it("strips markdown when plainText is true", () => {
-    const markdownContent =
-      "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
+  it("does not render raw HTML", () => {
+    const { container } = render(
+      <MarkdownText>{"<script>alert('unsafe')</script>"}</MarkdownText>
+    );
 
-    render(<MarkdownText plainText>{markdownContent}</MarkdownText>);
-
-    // Check that markdown is stripped and rendered as plain text
-    const textContent = screen.getByText(/Hello World.*bold.*italic.*link/);
-    expect(textContent).toBeInTheDocument();
-    expect(screen.queryByRole("heading")).not.toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(container.querySelector("script")).not.toBeInTheDocument();
+    expect(screen.getByText(/script.*unsafe.*script/i)).toBeInTheDocument();
   });
 
   it("handles empty content gracefully", () => {

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -54,6 +54,15 @@ describe("MarkdownText", () => {
     expect(container.querySelector("pre code")).toBeInTheDocument();
   });
 
+  it("renders fenced code blocks without a language as a block, not inline", () => {
+    const { container } = render(
+      <MarkdownText>{"```\nplain block\n```"}</MarkdownText>
+    );
+
+    expect(container.querySelector("pre code")).toBeInTheDocument();
+    expect(screen.getByText(/plain block/)).toBeInTheDocument();
+  });
+
   it("handles empty content gracefully", () => {
     const { container } = render(<MarkdownText>{""}</MarkdownText>);
 

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -4,29 +4,28 @@ import MarkdownText from "./MarkdownText";
 
 describe("MarkdownText", () => {
   it("renders markdown content as HTML", () => {
-    const markdownContent = "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
-    
-    render(
-      <MarkdownText>
-        {markdownContent}
-      </MarkdownText>
-    );
+    const markdownContent =
+      "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
+
+    render(<MarkdownText>{markdownContent}</MarkdownText>);
 
     // Check that markdown is rendered as HTML
-    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Hello World");
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Hello World"
+    );
     expect(screen.getByText("bold")).toBeInTheDocument();
     expect(screen.getByText("italic")).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute("href", "https://example.com");
+    expect(screen.getByRole("link", { name: "link" })).toHaveAttribute(
+      "href",
+      "https://example.com"
+    );
   });
 
   it("strips markdown when plainText is true", () => {
-    const markdownContent = "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
-    
-    render(
-      <MarkdownText plainText>
-        {markdownContent}
-      </MarkdownText>
-    );
+    const markdownContent =
+      "# Hello World\n\nThis is **bold** and *italic* text with a [link](https://example.com).";
+
+    render(<MarkdownText plainText>{markdownContent}</MarkdownText>);
 
     // Check that markdown is stripped and rendered as plain text
     const textContent = screen.getByText(/Hello World.*bold.*italic.*link/);
@@ -36,20 +35,14 @@ describe("MarkdownText", () => {
   });
 
   it("handles empty content gracefully", () => {
-    const { container } = render(
-      <MarkdownText>
-        {""}
-      </MarkdownText>
-    );
+    const { container } = render(<MarkdownText>{""}</MarkdownText>);
 
     expect(container.firstChild).toBeInTheDocument();
   });
 
   it("applies custom className", () => {
     const { container } = render(
-      <MarkdownText className="custom-class">
-        {"Test content"}
-      </MarkdownText>
+      <MarkdownText className="custom-class">{"Test content"}</MarkdownText>
     );
 
     expect(container.firstChild).toHaveClass("custom-class");

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -42,18 +42,16 @@ describe("MarkdownText", () => {
     expect(screen.getByText(/First line\s+second line/)).toBeInTheDocument();
   });
 
-  it("resets inline code decoration inside fenced code blocks", () => {
+  it("renders fenced code blocks with syntax highlighting", () => {
     const { container } = render(
       <MarkdownText>{"```ts\nconst ready = true;\n```"}</MarkdownText>
     );
-    const codeBlock = container.querySelector("pre");
 
-    expect(codeBlock).toHaveClass(
-      "[&_code]:rounded-none",
-      "[&_code]:bg-transparent",
-      "[&_code]:p-0"
-    );
-    expect(codeBlock?.querySelector("code")).toBeInTheDocument();
+    // Syntax highlighting splits the code into separate tokens.
+    expect(screen.getByText("const")).toBeInTheDocument();
+    expect(screen.getByText("ready")).toBeInTheDocument();
+    expect(screen.getByText("true")).toBeInTheDocument();
+    expect(container.querySelector("pre code")).toBeInTheDocument();
   });
 
   it("handles empty content gracefully", () => {

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import MarkdownText from "./MarkdownText";
 
 describe("MarkdownText", () => {

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -10,6 +10,21 @@ interface MarkdownTextProps {
   className?: string;
 }
 
+interface HastNodeLike {
+  type: string;
+  value?: string;
+  children?: HastNodeLike[];
+}
+
+// Fenced code blocks without a language (e.g. plain ```) get no `language-x`
+// className on their <code> node, so we can't rely on that alone. Read the
+// raw hast tree instead, which is reliable regardless of language presence.
+const hastToText = (node: HastNodeLike): string => {
+  if (node.type === "text") return node.value ?? "";
+  if (node.children) return node.children.map(hastToText).join("");
+  return "";
+};
+
 /**
  * Render trusted project metadata as Markdown without enabling raw HTML.
  */
@@ -48,19 +63,24 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
               {children}
             </a>
           ),
-          code: ({ className: codeClassName, children }) => {
-            const languageMatch = /language-(\w+)/.exec(codeClassName || "");
-            if (!languageMatch) {
-              return (
-                <code className="rounded bg-base-300 px-1 py-0.5 font-mono text-sm">
-                  {children}
-                </code>
-              );
-            }
+          code: ({ children }) => (
+            <code className="rounded bg-base-300 px-1 py-0.5 font-mono text-sm">
+              {children}
+            </code>
+          ),
+          pre: ({ node }) => {
+            const codeNode = node?.children.find(
+              (child) => child.type === "element" && child.tagName === "code"
+            );
+            if (!codeNode || codeNode.type !== "element") return null;
+            const codeClassName = Array.isArray(codeNode.properties?.className)
+              ? codeNode.properties.className.join(" ")
+              : "";
+            const languageMatch = /language-(\w+)/.exec(codeClassName);
             return (
               <div className="rounded-box overflow-hidden">
                 <SyntaxHighlighter
-                  language={languageMatch[1]}
+                  language={languageMatch?.[1]}
                   style={isDark ? atomOneDark : atomOneLight}
                   customStyle={{
                     margin: 0,
@@ -69,12 +89,11 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
                   }}
                   wrapLongLines={true}
                 >
-                  {String(children).replace(/\n$/, "")}
+                  {hastToText(codeNode).replace(/\n$/, "")}
                 </SyntaxHighlighter>
               </div>
             );
           },
-          pre: ({ children }) => <>{children}</>,
           blockquote: ({ children }) => (
             <blockquote className="border-l-4 border-primary pl-4 italic text-base-content/70">
               {children}

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
+import SyntaxHighlighter from "react-syntax-highlighter";
+import { atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { atomOneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
 
 interface MarkdownTextProps {
   children: string;
@@ -13,6 +17,7 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
   children,
   className = "",
 }) => {
+  const isDark = useIsDarkTheme();
   return (
     <div className={`space-y-3 ${className}`.trim()}>
       <ReactMarkdown
@@ -43,16 +48,33 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
               {children}
             </a>
           ),
-          code: ({ children }) => (
-            <code className="rounded bg-base-300 px-1 py-0.5 font-mono text-sm">
-              {children}
-            </code>
-          ),
-          pre: ({ children }) => (
-            <pre className="overflow-x-auto rounded-box bg-base-300 p-3 text-sm [&_code]:rounded-none [&_code]:bg-transparent [&_code]:p-0">
-              {children}
-            </pre>
-          ),
+          code: ({ className: codeClassName, children }) => {
+            const languageMatch = /language-(\w+)/.exec(codeClassName || "");
+            if (!languageMatch) {
+              return (
+                <code className="rounded bg-base-300 px-1 py-0.5 font-mono text-sm">
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <div className="rounded-box overflow-hidden">
+                <SyntaxHighlighter
+                  language={languageMatch[1]}
+                  style={isDark ? atomOneDark : atomOneLight}
+                  customStyle={{
+                    margin: 0,
+                    padding: "0.75rem",
+                    fontSize: "0.875rem",
+                  }}
+                  wrapLongLines={true}
+                >
+                  {String(children).replace(/\n$/, "")}
+                </SyntaxHighlighter>
+              </div>
+            );
+          },
+          pre: ({ children }) => <>{children}</>,
           blockquote: ({ children }) => (
             <blockquote className="border-l-4 border-primary pl-4 italic text-base-content/70">
               {children}

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -1,0 +1,88 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+
+interface MarkdownTextProps {
+  children: string;
+  className?: string;
+  /**
+   * Whether to strip markdown for plain text display (useful for previews)
+   */
+  plainText?: boolean;
+}
+
+/**
+ * Component for rendering markdown text with consistent styling.
+ * Can be used for both full markdown rendering and plain text extraction.
+ */
+const MarkdownText: React.FC<MarkdownTextProps> = ({
+  children,
+  className = "",
+  plainText = false,
+}) => {
+  if (plainText) {
+    // Strip markdown syntax for plain text display (e.g., in cards)
+    const plainContent = children
+      .replace(/#+\s/g, "") // Remove headers
+      .replace(/\*\*(.*?)\*\*/g, "$1") // Remove bold
+      .replace(/\*(.*?)\*/g, "$1") // Remove italic
+      .replace(/`(.*?)`/g, "$1") // Remove inline code
+      .replace(/\[(.*?)\]\(.*?\)/g, "$1") // Remove links but keep text
+      .replace(/^\s*[-*+]\s/gm, "") // Remove list markers
+      .replace(/^\s*\d+\.\s/gm, "") // Remove numbered list markers
+      .replace(/\n\s*\n/g, " ") // Replace double newlines with space
+      .replace(/\n/g, " ") // Replace single newlines with space
+      .trim();
+
+    return <span className={className}>{plainContent}</span>;
+  }
+
+  return (
+    <div className={className}>
+      <ReactMarkdown
+        components={{
+          // Customize link rendering to open in new tab and style appropriately
+          a: ({ href, children, ...props }) => (
+            <a
+              href={href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="link link-primary"
+              {...props}
+            >
+              {children}
+            </a>
+          ),
+          // Customize code block styling
+          code: ({ className, children, ...props }) => {
+            const isInline = !className;
+            return (
+              <code
+                className={
+                  isInline
+                    ? "bg-base-300 px-1 py-0.5 rounded text-sm font-mono"
+                    : "block bg-base-300 p-3 rounded text-sm font-mono overflow-x-auto"
+                }
+                {...props}
+              >
+                {children}
+              </code>
+            );
+          },
+          // Customize blockquote styling
+          blockquote: ({ children, ...props }) => (
+            <blockquote
+              className="border-l-4 border-primary pl-4 italic text-base-content/70"
+              {...props}
+            >
+              {children}
+            </blockquote>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
+    </div>
+  );
+};
+
+export default MarkdownText;

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -26,9 +26,7 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
           h3: ({ children }) => (
             <h3 className="text-lg font-semibold">{children}</h3>
           ),
-          p: ({ children }) => (
-            <p className="whitespace-pre-wrap leading-relaxed">{children}</p>
-          ),
+          p: ({ children }) => <p className="leading-relaxed">{children}</p>,
           ul: ({ children }) => (
             <ul className="list-disc space-y-1 pl-6">{children}</ul>
           ),
@@ -51,7 +49,7 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
             </code>
           ),
           pre: ({ children }) => (
-            <pre className="overflow-x-auto rounded-box bg-base-300 p-3 text-sm">
+            <pre className="overflow-x-auto rounded-box bg-base-300 p-3 text-sm [&_code]:rounded-none [&_code]:bg-transparent [&_code]:p-0">
               {children}
             </pre>
           ),

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -1,9 +1,6 @@
 import React from "react";
 import ReactMarkdown from "react-markdown";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import { atomOneDark } from "react-syntax-highlighter/dist/cjs/styles/hljs";
-import { atomOneLight } from "react-syntax-highlighter/dist/cjs/styles/hljs";
-import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
+import CodeBlock from "@sharedComponents/CodeBlock.tsx";
 
 interface MarkdownTextProps {
   children: string;
@@ -32,7 +29,6 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
   children,
   className = "",
 }) => {
-  const isDark = useIsDarkTheme();
   return (
     <div className={`space-y-3 ${className}`.trim()}>
       <ReactMarkdown
@@ -78,20 +74,12 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
               : "";
             const languageMatch = /language-(\w+)/.exec(codeClassName);
             return (
-              <div className="rounded-box overflow-hidden">
-                <SyntaxHighlighter
-                  language={languageMatch?.[1]}
-                  style={isDark ? atomOneDark : atomOneLight}
-                  customStyle={{
-                    margin: 0,
-                    padding: "0.75rem",
-                    fontSize: "0.875rem",
-                  }}
-                  wrapLongLines={true}
-                >
-                  {hastToText(codeNode).replace(/\n$/, "")}
-                </SyntaxHighlighter>
-              </div>
+              <CodeBlock
+                language={languageMatch?.[1]}
+                wrapperClassName="rounded-box overflow-hidden"
+              >
+                {hastToText(codeNode).replace(/\n$/, "")}
+              </CodeBlock>
             );
           },
           blockquote: ({ children }) => (

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -4,76 +4,59 @@ import ReactMarkdown from "react-markdown";
 interface MarkdownTextProps {
   children: string;
   className?: string;
-  /**
-   * Whether to strip markdown for plain text display (useful for previews)
-   */
-  plainText?: boolean;
 }
 
 /**
- * Component for rendering markdown text with consistent styling.
- * Can be used for both full markdown rendering and plain text extraction.
+ * Render trusted project metadata as Markdown without enabling raw HTML.
  */
 const MarkdownText: React.FC<MarkdownTextProps> = ({
   children,
   className = "",
-  plainText = false,
 }) => {
-  if (plainText) {
-    // Strip markdown syntax for plain text display (e.g., in cards)
-    const plainContent = children
-      .replace(/#+\s/g, "") // Remove headers
-      .replace(/\*\*(.*?)\*\*/g, "$1") // Remove bold
-      .replace(/\*(.*?)\*/g, "$1") // Remove italic
-      .replace(/`(.*?)`/g, "$1") // Remove inline code
-      .replace(/\[(.*?)\]\(.*?\)/g, "$1") // Remove links but keep text
-      .replace(/^\s*[-*+]\s/gm, "") // Remove list markers
-      .replace(/^\s*\d+\.\s/gm, "") // Remove numbered list markers
-      .replace(/\n\s*\n/g, " ") // Replace double newlines with space
-      .replace(/\n/g, " ") // Replace single newlines with space
-      .trim();
-
-    return <span className={className}>{plainContent}</span>;
-  }
-
   return (
-    <div className={className}>
+    <div className={`space-y-3 ${className}`.trim()}>
       <ReactMarkdown
         components={{
-          // Customize link rendering to open in new tab and style appropriately
-          a: ({ href, children, ...props }) => (
+          h1: ({ children }) => (
+            <h1 className="text-2xl font-bold">{children}</h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="text-xl font-semibold">{children}</h2>
+          ),
+          h3: ({ children }) => (
+            <h3 className="text-lg font-semibold">{children}</h3>
+          ),
+          p: ({ children }) => (
+            <p className="whitespace-pre-wrap leading-relaxed">{children}</p>
+          ),
+          ul: ({ children }) => (
+            <ul className="list-disc space-y-1 pl-6">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="list-decimal space-y-1 pl-6">{children}</ol>
+          ),
+          a: ({ href, children }) => (
             <a
               href={href}
               target="_blank"
               rel="noopener noreferrer"
               className="link link-primary"
-              {...props}
             >
               {children}
             </a>
           ),
-          // Customize code block styling
-          code: ({ className, children, ...props }) => {
-            const isInline = !className;
-            return (
-              <code
-                className={
-                  isInline
-                    ? "bg-base-300 px-1 py-0.5 rounded text-sm font-mono"
-                    : "block bg-base-300 p-3 rounded text-sm font-mono overflow-x-auto"
-                }
-                {...props}
-              >
-                {children}
-              </code>
-            );
-          },
-          // Customize blockquote styling
-          blockquote: ({ children, ...props }) => (
-            <blockquote
-              className="border-l-4 border-primary pl-4 italic text-base-content/70"
-              {...props}
-            >
+          code: ({ children }) => (
+            <code className="rounded bg-base-300 px-1 py-0.5 font-mono text-sm">
+              {children}
+            </code>
+          ),
+          pre: ({ children }) => (
+            <pre className="overflow-x-auto rounded-box bg-base-300 p-3 text-sm">
+              {children}
+            </pre>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="border-l-4 border-primary pl-4 italic text-base-content/70">
               {children}
             </blockquote>
           ),

--- a/packages/frontend/src/sharedComponents/MarkdownText.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactMarkdown from "react-markdown";
 import CodeBlock from "@sharedComponents/CodeBlock.tsx";
+import type React from "react";
+import ReactMarkdown from "react-markdown";
 
 interface MarkdownTextProps {
   children: string;
@@ -68,7 +68,7 @@ const MarkdownText: React.FC<MarkdownTextProps> = ({
             const codeNode = node?.children.find(
               (child) => child.type === "element" && child.tagName === "code"
             );
-            if (!codeNode || codeNode.type !== "element") return null;
+            if (codeNode?.type !== "element") return null;
             const codeClassName = Array.isArray(codeNode.properties?.className)
               ? codeNode.properties.className.join(" ")
               : "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       react-dom:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       react-router-dom:
         specifier: ^7.18.1
         version: 7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -1065,8 +1068,14 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
@@ -1080,11 +1089,17 @@ packages:
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
 
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
   '@types/http-errors@2.0.5':
     resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
 
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/methods@1.1.4':
     resolution: {integrity: sha512-ymXWVrDiCxTBE3+RIrrP533E70eA+9qu7zdWoHuOmGujkYtzf4HQF96b8nwHLqhuf4ykX61IGRIB38CC6/sImQ==}
@@ -1094,6 +1109,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/multer@1.4.13':
     resolution: {integrity: sha512-bhhdtPw7JqCiEfC9Jimx5LqX9BDIPJEh2q/fQ4bqbBPtyEZYr3cvF22NwG0DmPZNYA0CAf2CnqDB4KIGGpJcaw==}
@@ -1147,6 +1165,9 @@ packages:
 
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -1270,6 +1291,9 @@ packages:
     engines: {node: '>=16.20.0'}
     cpu: [x64]
     os: [win32]
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -1409,6 +1433,9 @@ packages:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
     engines: {node: '>=8.0.0'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -1483,6 +1510,9 @@ packages:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1495,14 +1525,26 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
   character-entities-legacy@1.1.4:
     resolution: {integrity: sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
 
   character-entities@1.2.4:
     resolution: {integrity: sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw==}
 
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
   character-reference-invalid@1.1.4:
     resolution: {integrity: sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   charm@0.1.2:
     resolution: {integrity: sha512-syedaZ9cPe7r3hoQA9twWYKu5AIyCswN5+szkmPBe9ccdLrj4bYaCnLVPTLd2kgVRc7+zoX4tyPgRnFKCj5YjQ==}
@@ -1539,6 +1581,9 @@ packages:
 
   comma-separated-tokens@1.0.8:
     resolution: {integrity: sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@2.15.1:
     resolution: {integrity: sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==}
@@ -1696,6 +1741,9 @@ packages:
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -1723,6 +1771,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
@@ -1816,6 +1867,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -1857,6 +1911,9 @@ packages:
   express@4.22.2:
     resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
     engines: {node: '>= 0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   extrareqp2@1.0.0:
     resolution: {integrity: sha512-Gum0g1QYb6wpPJCVypWP3bbIuaibcFiJcpuPM10YSXp/tzqi84x9PJageob+eN4xVRIOto4wjSGNLyMD54D2xA==}
@@ -2003,6 +2060,12 @@ packages:
   hast-util-parse-selector@2.2.5:
     resolution: {integrity: sha512-7j6mrk/qqkSehsM92wQjdIgWM2/BW61u/53G6xmC8i1OmEdKLHbk419QKQUjz6LglWsfqoiHmyMRkP1BGjecNQ==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
 
@@ -2021,6 +2084,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
@@ -2055,6 +2121,9 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
@@ -2066,8 +2135,14 @@ packages:
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
   is-alphanumerical@1.0.4:
     resolution: {integrity: sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -2079,6 +2154,9 @@ packages:
 
   is-decimal@1.0.4:
     resolution: {integrity: sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2095,9 +2173,16 @@ packages:
   is-hexadecimal@1.0.4:
     resolution: {integrity: sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw==}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
@@ -2297,6 +2382,9 @@ packages:
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
 
@@ -2333,6 +2421,30 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
@@ -2346,6 +2458,69 @@ packages:
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2504,6 +2679,9 @@ packages:
 
   parse-entities@2.0.0:
     resolution: {integrity: sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==}
+
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
@@ -2666,6 +2844,9 @@ packages:
   property-information@5.6.0:
     resolution: {integrity: sha512-YUHSPk+A30YPv+0Qf8i9Mbfe/C0hdPXk1s1jPVToV8pk8BQtpw10ct89Eo7OWkutrwqvT0eicAxlOg3dOAu8JA==}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2707,6 +2888,12 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
@@ -2760,6 +2947,12 @@ packages:
 
   refractor@3.6.0:
     resolution: {integrity: sha512-MY9W41IOWxxk31o+YvFCNyNzdkc9M20NoZK5vq6jkv4I/uh2zkWcfudj0Q1fovjUQJrNewS9NMzeTtqPf+n5EA==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -2913,6 +3106,9 @@ packages:
   space-separated-tokens@1.1.5:
     resolution: {integrity: sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA==}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
 
@@ -2955,6 +3151,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
@@ -2966,6 +3165,12 @@ packages:
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
@@ -3057,6 +3262,12 @@ packages:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
     hasBin: true
 
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-deepmerge@6.2.1:
     resolution: {integrity: sha512-8CYSLazCyj0DJDpPIxOFzJG46r93uh6EynYjuey+bxcLltBeqZL7DMfaE5ZPzZNFlav7wx+2TDa/mBl8gkTYzw==}
     engines: {node: '>=14.13.1'}
@@ -3104,6 +3315,24 @@ packages:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
@@ -3118,6 +3347,12 @@ packages:
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@8.1.4:
     resolution: {integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==}
@@ -3328,6 +3563,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -3935,7 +4173,15 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/deep-eql@4.0.2': {}
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
 
   '@types/estree@1.0.9': {}
 
@@ -3957,15 +4203,25 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 2.0.11
+
   '@types/http-errors@2.0.5': {}
 
   '@types/lodash@4.17.24': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 2.0.11
 
   '@types/methods@1.1.4': {}
 
   '@types/mime-types@3.0.1': {}
 
   '@types/mime@1.3.5': {}
+
+  '@types/ms@2.1.0': {}
 
   '@types/multer@1.4.13':
     dependencies:
@@ -4040,6 +4296,8 @@ snapshots:
 
   '@types/unist@2.0.11': {}
 
+  '@types/unist@3.0.3': {}
+
   '@types/ws@8.18.1':
     dependencies:
       '@types/node': 22.20.1
@@ -4103,6 +4361,8 @@ snapshots:
 
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1))':
     dependencies:
@@ -4238,6 +4498,8 @@ snapshots:
 
   atomic-sleep@1.0.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   base64-js@1.5.1: {}
@@ -4322,6 +4584,8 @@ snapshots:
 
   camelcase@5.3.1: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@3.0.0:
@@ -4334,11 +4598,19 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  character-entities-html4@2.1.0: {}
+
   character-entities-legacy@1.1.4: {}
+
+  character-entities-legacy@3.0.0: {}
 
   character-entities@1.2.4: {}
 
+  character-entities@2.0.2: {}
+
   character-reference-invalid@1.1.4: {}
+
+  character-reference-invalid@2.0.1: {}
 
   charm@0.1.2: {}
 
@@ -4383,6 +4655,8 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@1.0.8: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@2.15.1: {}
 
@@ -4536,6 +4810,10 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-extend@0.6.0: {}
 
   degenerator@5.0.1:
@@ -4553,6 +4831,10 @@ snapshots:
   destroy@1.2.0: {}
 
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dezalgo@1.0.4:
     dependencies:
@@ -4654,6 +4936,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -4713,6 +4997,8 @@ snapshots:
       vary: 1.1.2
     transitivePeerDependencies:
       - supports-color
+
+  extend@3.0.2: {}
 
   extrareqp2@1.0.0(debug@4.3.7):
     dependencies:
@@ -4854,6 +5140,30 @@ snapshots:
 
   hast-util-parse-selector@2.2.5: {}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hastscript@6.0.0:
     dependencies:
       '@types/hast': 2.3.10
@@ -4875,6 +5185,8 @@ snapshots:
       - '@noble/hashes'
 
   html-escaper@2.0.2: {}
+
+  html-url-attributes@3.0.1: {}
 
   http-errors@2.0.1:
     dependencies:
@@ -4912,16 +5224,25 @@ snapshots:
 
   ini@1.3.8: {}
 
+  inline-style-parser@0.2.7: {}
+
   ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
   is-alphabetical@1.0.4: {}
 
+  is-alphabetical@2.0.1: {}
+
   is-alphanumerical@1.0.4:
     dependencies:
       is-alphabetical: 1.0.4
       is-decimal: 1.0.4
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-binary-path@2.1.0:
     dependencies:
@@ -4933,6 +5254,8 @@ snapshots:
 
   is-decimal@1.0.4: {}
 
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -4943,7 +5266,11 @@ snapshots:
 
   is-hexadecimal@1.0.4: {}
 
+  is-hexadecimal@2.0.1: {}
+
   is-number@7.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-potential-custom-element-name@1.0.1: {}
 
@@ -5116,6 +5443,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
+  longest-streak@3.1.0: {}
+
   lowlight@1.20.0:
     dependencies:
       fault: 1.0.4
@@ -5149,6 +5478,95 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
   mdn-data@2.27.1: {}
 
   media-typer@0.3.0: {}
@@ -5156,6 +5574,139 @@ snapshots:
   merge-descriptors@1.0.3: {}
 
   methods@1.1.2: {}
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -5322,6 +5873,16 @@ snapshots:
       is-alphanumerical: 1.0.4
       is-decimal: 1.0.4
       is-hexadecimal: 1.0.4
+
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
 
   parse5@8.0.1:
     dependencies:
@@ -5535,6 +6096,8 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  property-information@7.2.0: {}
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5586,6 +6149,24 @@ snapshots:
       scheduler: 0.27.0
 
   react-is@17.0.2: {}
+
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.17
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -5647,6 +6228,23 @@ snapshots:
       hastscript: 6.0.0
       parse-entities: 2.0.0
       prismjs: 1.27.0
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -5852,6 +6450,8 @@ snapshots:
 
   space-separated-tokens@1.1.5: {}
 
+  space-separated-tokens@2.0.2: {}
+
   spawn-command@0.0.2: {}
 
   split2@4.2.0: {}
@@ -5888,6 +6488,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5897,6 +6502,14 @@ snapshots:
       min-indent: 1.0.1
 
   strip-json-comments@2.0.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   superagent@10.3.0:
     dependencies:
@@ -5985,6 +6598,10 @@ snapshots:
 
   tree-kill@1.2.2: {}
 
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
   ts-deepmerge@6.2.1: {}
 
   tslib@1.9.3: {}
@@ -6048,6 +6665,39 @@ snapshots:
 
   undici@7.28.0: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   unpipe@1.0.0: {}
 
   util-deprecate@1.0.2: {}
@@ -6055,6 +6705,16 @@ snapshots:
   utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@8.1.4(@types/node@22.20.1)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.1):
     dependencies:
@@ -6231,3 +6891,5 @@ snapshots:
       yargs-parser: 21.1.1
 
   zod@3.25.76: {}
+
+  zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Render long project descriptions as Markdown (headings, bold/italic, lists, links, blockquotes, code) while short descriptions stay plain text.
- Add a theme-native Markdown editing experience on the app edit page: a full-width Short Description field stacked under Version, and a Long Description field with a live left-editor/right-preview split.
- Fenced code blocks in descriptions get real syntax highlighting via `react-syntax-highlighter`, matching the existing file-browser preview, including a shared `CodeBlock` component extracted from the three near-duplicate highlighter blocks that previously lived in `AppCodePreview.tsx`.
- Detects fenced-vs-inline code reliably via the raw hast node rather than relying solely on a `language-x` className, since language-less fenced blocks (plain ` ``` `) have no such class and would otherwise render inline and lose formatting.
- Keeps short-description fallback behavior when no long description is available.

## Notes
- This revives a branch I'd started a while back and picked back up now.
- Opened as a draft — happy to squash before merge if preferred; this repo appears to use regular merge commits (not squash-merge) based on recent PR history, so the 10 commits here would land as-is with a plain merge.

## Test plan
- [x] Full frontend test suite passes
- [x] Manually verified rendering and editing on a local deployment across the fenced-code, language-less-code, and short/long description fallback cases