### PR TITLE
perf(frontend): use react-syntax-highlighter light build with scoped languages

### DIFF
--- a/packages/frontend/src/sharedComponents/CodeBlock.tsx
+++ b/packages/frontend/src/sharedComponents/CodeBlock.tsx
@@ -1,10 +1,53 @@
 import { useIsDarkTheme } from "@hooks/useIsDarkTheme.ts";
 import type React from "react";
-import SyntaxHighlighter from "react-syntax-highlighter";
-import {
-  atomOneDark,
-  atomOneLight,
-} from "react-syntax-highlighter/dist/cjs/styles/hljs";
+import bash from "react-syntax-highlighter/dist/esm/languages/hljs/bash.js";
+import c from "react-syntax-highlighter/dist/esm/languages/hljs/c.js";
+import cpp from "react-syntax-highlighter/dist/esm/languages/hljs/cpp.js";
+import css from "react-syntax-highlighter/dist/esm/languages/hljs/css.js";
+import go from "react-syntax-highlighter/dist/esm/languages/hljs/go.js";
+import java from "react-syntax-highlighter/dist/esm/languages/hljs/java.js";
+import javascript from "react-syntax-highlighter/dist/esm/languages/hljs/javascript.js";
+import json from "react-syntax-highlighter/dist/esm/languages/hljs/json.js";
+import less from "react-syntax-highlighter/dist/esm/languages/hljs/less.js";
+import markdown from "react-syntax-highlighter/dist/esm/languages/hljs/markdown.js";
+import php from "react-syntax-highlighter/dist/esm/languages/hljs/php.js";
+import python from "react-syntax-highlighter/dist/esm/languages/hljs/python.js";
+import ruby from "react-syntax-highlighter/dist/esm/languages/hljs/ruby.js";
+import rust from "react-syntax-highlighter/dist/esm/languages/hljs/rust.js";
+import scss from "react-syntax-highlighter/dist/esm/languages/hljs/scss.js";
+import sql from "react-syntax-highlighter/dist/esm/languages/hljs/sql.js";
+import typescript from "react-syntax-highlighter/dist/esm/languages/hljs/typescript.js";
+import xml from "react-syntax-highlighter/dist/esm/languages/hljs/xml.js";
+import yaml from "react-syntax-highlighter/dist/esm/languages/hljs/yaml.js";
+import SyntaxHighlighter from "react-syntax-highlighter/dist/esm/light.js";
+import atomOneDark from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-dark.js";
+import atomOneLight from "react-syntax-highlighter/dist/esm/styles/hljs/atom-one-light.js";
+
+// Explicit per-language registration on the "light" build instead of the
+// default import, which bundles all ~190 hljs grammars regardless of use.
+// javascript/typescript/xml/bash carry hljs aliases (jsx, tsx, html, sh)
+// that resolve to these automatically; scss has no "sass" alias so it's
+// registered a second time under that name.
+SyntaxHighlighter.registerLanguage("bash", bash);
+SyntaxHighlighter.registerLanguage("c", c);
+SyntaxHighlighter.registerLanguage("cpp", cpp);
+SyntaxHighlighter.registerLanguage("css", css);
+SyntaxHighlighter.registerLanguage("go", go);
+SyntaxHighlighter.registerLanguage("java", java);
+SyntaxHighlighter.registerLanguage("javascript", javascript);
+SyntaxHighlighter.registerLanguage("json", json);
+SyntaxHighlighter.registerLanguage("less", less);
+SyntaxHighlighter.registerLanguage("markdown", markdown);
+SyntaxHighlighter.registerLanguage("php", php);
+SyntaxHighlighter.registerLanguage("python", python);
+SyntaxHighlighter.registerLanguage("ruby", ruby);
+SyntaxHighlighter.registerLanguage("rust", rust);
+SyntaxHighlighter.registerLanguage("scss", scss);
+SyntaxHighlighter.registerLanguage("sass", scss);
+SyntaxHighlighter.registerLanguage("sql", sql);
+SyntaxHighlighter.registerLanguage("typescript", typescript);
+SyntaxHighlighter.registerLanguage("xml", xml);
+SyntaxHighlighter.registerLanguage("yaml", yaml);
 
 interface CodeBlockProps {
   children: string;

--- a/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
+++ b/packages/frontend/src/sharedComponents/MarkdownText.test.tsx
@@ -47,10 +47,10 @@ describe("MarkdownText", () => {
       <MarkdownText>{"```ts\nconst ready = true;\n```"}</MarkdownText>
     );
 
-    // Syntax highlighting splits the code into separate tokens.
+    // Syntax highlighting gives keywords/literals their own styled spans.
     expect(screen.getByText("const")).toBeInTheDocument();
-    expect(screen.getByText("ready")).toBeInTheDocument();
     expect(screen.getByText("true")).toBeInTheDocument();
+    expect(container.querySelector("pre code span[style]")).toBeInTheDocument();
     expect(container.querySelector("pre code")).toBeInTheDocument();
   });
 

--- a/packages/frontend/src/sharedComponents/react-syntax-highlighter-light.d.ts
+++ b/packages/frontend/src/sharedComponents/react-syntax-highlighter-light.d.ts
@@ -1,0 +1,33 @@
+// react-syntax-highlighter ships no "types"/"exports" field, and
+// @types/react-syntax-highlighter's deep-import declarations aren't loaded
+// here since tsconfig's "types" array only lists "node"/"vite/client".
+// These cover the "light" build subpaths CodeBlock.tsx imports directly
+// to register only the languages it needs, instead of the default export
+// which bundles every hljs grammar.
+declare module "react-syntax-highlighter/dist/esm/light.js" {
+  import type React from "react";
+
+  interface LightSyntaxHighlighterProps {
+    language?: string;
+    style?: Record<string, unknown>;
+    customStyle?: React.CSSProperties;
+    showLineNumbers?: boolean;
+    wrapLines?: boolean;
+    wrapLongLines?: boolean;
+    children: string;
+  }
+
+  export default class SyntaxHighlighter extends React.Component<LightSyntaxHighlighterProps> {
+    static registerLanguage(name: string, language: unknown): void;
+  }
+}
+
+declare module "react-syntax-highlighter/dist/esm/languages/hljs/*.js" {
+  const language: unknown;
+  export default language;
+}
+
+declare module "react-syntax-highlighter/dist/esm/styles/hljs/*.js" {
+  const style: Record<string, unknown>;
+  export default style;
+}


### PR DESCRIPTION
## Summary

Investigated migrating to TanStack Highlight/Markdown and built a metrics-based case for it. Before touching any new dependency, this PR ships the free, zero-risk fix that captures most of the available win:

- `CodeBlock.tsx` imported the default `react-syntax-highlighter` build, which bundles ~190 hljs grammars regardless of use. Switched to the `light` build and registered only the ~19 languages the app actually maps file extensions to (`getLanguageFromFile`/`fileUtils.ts`).
- Vendor chunk: **449 KB → 175 KB gzip** (measured via `pnpm run build`, before/after).
- Added a small ambient `.d.ts` for the deep `react-syntax-highlighter/dist/esm/...` subpaths, since `@types/react-syntax-highlighter`'s declarations for these paths aren't loaded here (tsconfig's `types` array only lists `node`/`vite/client`).
- Updated a `MarkdownText` test that was inadvertently relying on `language="ts"` **not** resolving under the old full build (falling back to `highlightAuto`). It now resolves correctly via hljs's built-in `ts`/`tsx` alias on the TypeScript grammar, which surfaced a separate, pre-existing `react-syntax-highlighter` `wrapLongLines` quirk (drops the `hljs-attr` span for bare identifiers) — reproducible on the old code too with `language="typescript"`, unrelated to this change. Test now asserts on stable signals (`const`/`true` keyword-literal highlighting, presence of a styled span) instead.

Follow-up (not in this PR): evaluated `@tanstack/highlight` and `@tanstack/markdown` for a further reduction. `@tanstack/markdown` looks like a genuine future win (~7 KB gzip vs `react-markdown`'s ~35 KB, no obvious feature gap) but both packages are very new (first published 5 weeks ago, still 0.0.x, ~1K weekly downloads) — holding off pending stabilization. `@tanstack/highlight` isn't viable yet: it's missing grammars for C, C++, Java, PHP, Ruby, Go, Rust, SCSS, Sass, and Less, several of which (C/C++) are core to this project's badge firmware use case.

## Test plan

- [x] `pnpm exec vitest run` — full frontend suite passes (91 passed, 1 skipped)
- [x] `pnpm run lint` — clean
- [x] `pnpm run check:ts` — clean
- [x] `pnpm run build` — verified vendor chunk gzip size before/after