### PR TITLE
fix (ui): avoid auth flash on private pages during SSO check

### DIFF
--- a/packages/frontend/src/__test__/renderWithRouter.tsx
+++ b/packages/frontend/src/__test__/renderWithRouter.tsx
@@ -10,6 +10,7 @@ const TestSessionProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const session = {
+    status: "authenticated" as const,
     user: {
       name: "Test User",
       email: "",
@@ -18,6 +19,7 @@ const TestSessionProvider: React.FC<{ children: React.ReactNode }> = ({
     },
     keycloak: {
       authenticated: true,
+      token: "test-token",
       login: vitest.fn() as unknown,
       logout: vitest.fn() as unknown,
       updateToken: vitest.fn().mockResolvedValue(true) as unknown,

--- a/packages/frontend/src/api/apiClient.ts
+++ b/packages/frontend/src/api/apiClient.ts
@@ -208,15 +208,40 @@ export const publicApiClient: ApiClient = wrapClient(
   createORPCClient(createLink()) as OrpcClient
 );
 
-async function getFreshToken(keycloak: Keycloak | undefined) {
-  await keycloak?.updateToken(30);
-  return keycloak?.token;
+/** Refresh access token if it expires within this many seconds. */
+export const TOKEN_MIN_VALIDITY_SECONDS = 30;
+
+/**
+ * Ensures a usable access token (single refresh path for all authorized calls).
+ * Call sites should not invoke `keycloak.updateToken` themselves.
+ */
+export async function getFreshToken(
+  keycloak: Keycloak | undefined
+): Promise<string | undefined> {
+  if (!keycloak) {
+    return undefined;
+  }
+  try {
+    await keycloak.updateToken(TOKEN_MIN_VALIDITY_SECONDS);
+  } catch (error) {
+    console.error("Failed to refresh access token", error);
+    throw new Error("Failed to update token. Please try logging in again.");
+  }
+  return keycloak.token;
 }
 
 export async function getAuthorizationHeader(keycloak: Keycloak | undefined) {
-  return { authorization: `Bearer ${await getFreshToken(keycloak)}` };
+  const token = await getFreshToken(keycloak);
+  if (!token) {
+    throw new Error("Authentication required");
+  }
+  return { authorization: `Bearer ${token}` };
 }
 
+/**
+ * Authorized API client. Token refresh runs per request via the link headers
+ * callback — do not call `updateToken` again around these calls.
+ */
 export const getFreshAuthorizedApiClient = async (
   keycloak: Keycloak
 ): Promise<ApiClient> => {

--- a/packages/frontend/src/hooks/useDraftProject.ts
+++ b/packages/frontend/src/hooks/useDraftProject.ts
@@ -1,6 +1,7 @@
 import { getFreshAuthorizedApiClient } from "@api/apiClient.ts";
 import { useAsyncResource } from "@hooks/useAsyncResource.ts";
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
+import type { SessionStatus } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import {
   type DraftProjectErrorCode,
   draftProjectErrorFromStatus,
@@ -11,13 +12,19 @@ import { useEffect, useState } from "react";
 
 export type PossiblyStaleProject = ProjectDetails & { stale?: true };
 
-export const useDraftProject = (slug: string, keycloak?: Keycloak) => {
+export const useDraftProject = (
+  slug: string,
+  keycloak: Keycloak | undefined,
+  sessionStatus: SessionStatus
+) => {
   const [project, setProject] = useState<PossiblyStaleProject | null>(null);
-  const shouldFetchProject = Boolean(keycloak) && (!project || project.stale);
+  const canFetch =
+    sessionStatus === "authenticated" && Boolean(keycloak?.authenticated);
+  const shouldFetchProject = canFetch && (!project || project.stale);
   const {
     data: fetchedProject,
     error: fetchError,
-    loading,
+    loading: fetchLoading,
   } = useAsyncResource(
     async () => {
       if (!keycloak) {
@@ -51,11 +58,17 @@ export const useDraftProject = (slug: string, keycloak?: Keycloak) => {
     }
   }, [fetchedProject]);
 
-  const error: DraftProjectErrorCode | null = !keycloak
-    ? "authentication"
-    : fetchError
-      ? normalizeDraftProjectError(fetchError)
-      : null;
+  const loading =
+    sessionStatus === "loading" || (canFetch && fetchLoading && !project);
+
+  const error: DraftProjectErrorCode | null =
+    sessionStatus === "loading"
+      ? null
+      : sessionStatus === "anonymous" || !keycloak
+        ? "authentication"
+        : fetchError
+          ? normalizeDraftProjectError(fetchError)
+          : null;
 
   return { project, setProject, loading, error };
 };

--- a/packages/frontend/src/hooks/useUserDraftProjectsFetcher.ts
+++ b/packages/frontend/src/hooks/useUserDraftProjectsFetcher.ts
@@ -1,4 +1,7 @@
-import { publicApiClient as defaultApiClient } from "@api/apiClient.ts";
+import {
+  publicApiClient as defaultApiClient,
+  getAuthorizationHeader,
+} from "@api/apiClient.ts";
 import type { AppFetcher } from "@sharedComponents/AppGridWithFilterAndPagination.tsx";
 import type { User } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import type Keycloak from "keycloak-js";
@@ -19,19 +22,13 @@ export const useUserDraftProjectsFetcher = ({
     if (!user || !keycloak) {
       throw new Error("Authentication required");
     }
-    await keycloak.updateToken(30).catch((e) => {
-      console.error("Failed to update token", e);
-      throw new Error("Failed to update token. Please try logging in again.");
-    });
 
     const result = await apiClient
       ?.getUserDraftProjects({
         params: {
           userId: user.id,
         },
-        headers: {
-          authorization: `Bearer ${keycloak.token}`,
-        },
+        headers: await getAuthorizationHeader(keycloak),
       })
       .catch((e) => {
         console.error("Failed to fetch draft projects", e);

--- a/packages/frontend/src/pages/AppCreationPage/AppCreationPage.test.tsx
+++ b/packages/frontend/src/pages/AppCreationPage/AppCreationPage.test.tsx
@@ -31,6 +31,7 @@ const renderLoggedOut = () =>
     <MemoryRouter>
       <SessionContext
         value={{
+          status: "anonymous",
           user: undefined,
           keycloak: { authenticated: false } as Keycloak,
         }}

--- a/packages/frontend/src/pages/AppCreationPage/AppCreationPage.tsx
+++ b/packages/frontend/src/pages/AppCreationPage/AppCreationPage.tsx
@@ -2,9 +2,9 @@ import { getFreshAuthorizedApiClient } from "@api/apiClient.ts";
 import { useTitle } from "@hooks/useTitle.ts";
 import { VALID_SLUG_REGEX } from "@shared/contracts/slug.ts";
 import { assertDefined } from "@shared/util/assertions.ts";
+import { AuthGate } from "@sharedComponents/keycloakSession/AuthGate.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import PageLayout from "@sharedComponents/PageLayout.tsx";
-import { PleaseLoginMessage } from "@sharedComponents/PleaseLoginMessage.tsx";
 import type React from "react";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -16,8 +16,6 @@ export interface AppCreationFormData {
   slug: string;
 }
 
-// Define the valid slug regex
-
 const initialForm: AppCreationFormData = {
   slug: "",
 };
@@ -26,7 +24,7 @@ const AppCreationPage: React.FC = () => {
   useTitle("Create project");
   const [form, setForm] = useState<AppCreationFormData>(initialForm);
   const [error, setError] = useState<string | null>(null);
-  const { user, keycloak } = useSession();
+  const { keycloak } = useSession();
   const navigate = useNavigate();
   const handleFormChange = (changes: Partial<AppCreationFormData>) => {
     setForm((prev) => ({
@@ -67,28 +65,21 @@ const AppCreationPage: React.FC = () => {
   // Check if slug is valid
   const isSlugValid = VALID_SLUG_REGEX.test(form.slug);
 
-  // Check if user is logged in
-  const userIsLoggedIn = keycloak?.authenticated && user?.id;
-
   return (
     <PageLayout data-testid="app-creation-page">
       <AppCreationBreadcrumb />
       <h1 className="text-3xl font-bold mb-6">Create a New Project</h1>
-      {!userIsLoggedIn ? (
-        <PleaseLoginMessage whatToSee="create a project" />
-      ) : (
-        <>
-          {error && (
-            <div role="alert" className="alert alert-error mb-4">
-              {error}
-            </div>
-          )}
-          <form className="space-y-8" onSubmit={handleSubmit}>
-            <AppCreationBasicInfo form={form} onChange={handleFormChange} />
-            <AppCreationActions isSlugValid={isSlugValid} />
-          </form>
-        </>
-      )}
+      <AuthGate whatToSee="create a project">
+        {error && (
+          <div role="alert" className="alert alert-error mb-4">
+            {error}
+          </div>
+        )}
+        <form className="space-y-8" onSubmit={handleSubmit}>
+          <AppCreationBasicInfo form={form} onChange={handleFormChange} />
+          <AppCreationActions isSlugValid={isSlugValid} />
+        </form>
+      </AuthGate>
     </PageLayout>
   );
 };

--- a/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
+++ b/packages/frontend/src/pages/AppDetailPage/AppDetailPage.test.tsx
@@ -138,7 +138,7 @@ describe("AppDetailPage", { timeout: 1000_000 }, () => {
   it("does not show the rating control when logged out", async () => {
     renderWithoutProviders(
       <MemoryRouter>
-        <SessionContext value={{}}>
+        <SessionContext value={{ status: "anonymous" }}>
           <AppDetailPage
             apiClient={apiClientWithApps(dummyApps)}
             slug="dummy-app-1"

--- a/packages/frontend/src/pages/AppEditPage/AppEditPage.tsx
+++ b/packages/frontend/src/pages/AppEditPage/AppEditPage.tsx
@@ -8,6 +8,7 @@ import type { AppMetadataJSON } from "@shared/domain/readModels/project/AppMetad
 import type { ProjectDetails } from "@shared/domain/readModels/project/ProjectDetails.ts";
 import type { VariantJSON } from "@shared/domain/readModels/project/VariantJSON.ts";
 import { assertDefined } from "@shared/util/assertions.ts";
+import { AuthGate } from "@sharedComponents/keycloakSession/AuthGate.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import PageLayout from "@sharedComponents/PageLayout.tsx";
 import type React from "react";
@@ -29,11 +30,12 @@ const AppEditPage: React.FC<{
   slug: string;
 }> = ({ slug }) => {
   const [previewedFile, setPreviewedFile] = useState<string | null>(null);
-  const { user, keycloak } = useSession();
+  const { user, keycloak, status } = useSession();
   const navigate = useNavigate();
   const { project, setProject, loading, error } = useDraftProject(
     slug,
-    keycloak
+    keycloak,
+    status
   );
 
   const setAppMetadata = (
@@ -71,7 +73,6 @@ const AppEditPage: React.FC<{
     uploadedPaths?: string[];
   }) => {
     assertDefined(keycloak);
-    await keycloak.updateToken(30);
     const updatedDraftProject = await (
       await getFreshAuthorizedApiClient(keycloak)
     ).getDraftProject({
@@ -203,7 +204,6 @@ const AppEditPage: React.FC<{
   const handleSetIcon = async (filePath: string) => {
     assertDefined(keycloak);
     try {
-      await keycloak.updateToken(30);
       const client = await getFreshAuthorizedApiClient(keycloak);
       const setIconResult = await client.setDraftIconFromFile({
         params: { slug },
@@ -239,30 +239,32 @@ const AppEditPage: React.FC<{
 
   return (
     <PageLayout data-testid="app-edit-page">
-      <AppEditStateView
-        loading={loading}
-        error={error ?? (!project || !appMetadata ? "not_found" : null)}
-        onLogin={() => keycloak?.login()}
-      >
-        {project && appMetadata && keycloak && (
-          <AppEditForm
-            project={project as ProjectDetails}
-            appMetadata={appMetadata as ProjectEditFormData}
-            slug={slug}
-            keycloak={keycloak}
-            previewedFile={previewedFile}
-            mainExecutable={mainExecutable}
-            onPreviewFile={handlePreviewFile}
-            onSetIcon={handleSetIcon}
-            onDeleteFile={handleDeleteFile}
-            onSetMainExecutable={onSetMainExecutable}
-            onUploadSuccess={updateDraftFiles}
-            onFormChange={handleFormChange}
-            onSubmit={handleSubmit}
-            onDeleteApplication={handleDeleteApplication}
-          />
-        )}
-      </AppEditStateView>
+      <AuthGate whatToSee="edit this project">
+        <AppEditStateView
+          loading={loading}
+          error={error ?? (!project || !appMetadata ? "not_found" : null)}
+          onLogin={() => keycloak?.login()}
+        >
+          {project && appMetadata && keycloak && (
+            <AppEditForm
+              project={project as ProjectDetails}
+              appMetadata={appMetadata as ProjectEditFormData}
+              slug={slug}
+              keycloak={keycloak}
+              previewedFile={previewedFile}
+              mainExecutable={mainExecutable}
+              onPreviewFile={handlePreviewFile}
+              onSetIcon={handleSetIcon}
+              onDeleteFile={handleDeleteFile}
+              onSetMainExecutable={onSetMainExecutable}
+              onUploadSuccess={updateDraftFiles}
+              onFormChange={handleFormChange}
+              onSubmit={handleSubmit}
+              onDeleteApplication={handleDeleteApplication}
+            />
+          )}
+        </AppEditStateView>
+      </AuthGate>
     </PageLayout>
   );
 };

--- a/packages/frontend/src/pages/MyProjectsPage/MyProjectsPage.tsx
+++ b/packages/frontend/src/pages/MyProjectsPage/MyProjectsPage.tsx
@@ -1,9 +1,10 @@
 import { useTitle } from "@hooks/useTitle.ts";
 import { useUserDraftProjectsFetcher } from "@hooks/useUserDraftProjectsFetcher.ts";
 import { AppGridWithFilterAndPagination } from "@sharedComponents/AppGridWithFilterAndPagination.tsx";
+import { AuthGate } from "@sharedComponents/keycloakSession/AuthGate.tsx";
 import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import PageLayout from "@sharedComponents/PageLayout.tsx";
-import { PleaseLoginMessage } from "@sharedComponents/PleaseLoginMessage.tsx";
+import Spinner from "@sharedComponents/Spinner.tsx";
 import { memo, useState } from "react";
 import { publicApiClient as defaultApiClient } from "../../api/apiClient.ts";
 
@@ -26,16 +27,18 @@ const MyProjectsPage = memo(({ apiClient = defaultApiClient }: AppProps) => {
       setSearchQuery={setSearchQuery}
       data-testid="my-projects-page"
     >
-      {appFetcher ? (
-        <AppGridWithFilterAndPagination
-          appFetcher={appFetcher}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          editable={true}
-        />
-      ) : (
-        <PleaseLoginMessage whatToSee={"see your projects"} />
-      )}
+      <AuthGate whatToSee="see your projects">
+        {appFetcher ? (
+          <AppGridWithFilterAndPagination
+            appFetcher={appFetcher}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            editable={true}
+          />
+        ) : (
+          <Spinner />
+        )}
+      </AuthGate>
     </PageLayout>
   );
 });

--- a/packages/frontend/src/sharedComponents/Header.tsx
+++ b/packages/frontend/src/sharedComponents/Header.tsx
@@ -52,13 +52,14 @@ const SearchField: React.FC<SearchProps> = ({
 
 const Header: React.FC<Partial<SearchProps>> = (searchProps) => {
   const [mobileOpen, setMobileOpen] = useState(false);
-  const { user, keycloak } = useSession();
+  const { user, keycloak, status } = useSession();
   const searchEnabled =
     searchProps.searchQuery !== undefined &&
     searchProps.setSearchQuery !== undefined;
   const checkedSearchProps: SearchProps | undefined = searchEnabled
     ? (searchProps as SearchProps)
     : undefined;
+  const sessionReady = status !== "loading";
 
   async function login() {
     await keycloak?.login();
@@ -173,7 +174,14 @@ const Header: React.FC<Partial<SearchProps>> = (searchProps) => {
             </MLink>
           ))}
           <div className="divider my-1" />
-          {user ? (
+          {!sessionReady ? (
+            <div
+              className="px-3 py-2 text-sm opacity-60"
+              data-testid="mobile-session-loading"
+            >
+              Checking session…
+            </div>
+          ) : user ? (
             <>
               <div className="px-3 py-2">
                 <p className="text-sm font-medium truncate">{user.name}</p>

--- a/packages/frontend/src/sharedComponents/ProfileIcon.tsx
+++ b/packages/frontend/src/sharedComponents/ProfileIcon.tsx
@@ -6,7 +6,8 @@ import { useEffect, useRef, useState } from "react";
 const ProfileIcon: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
-  const { user, keycloak } = useSession();
+  const { user, keycloak, status } = useSession();
+  const sessionReady = status !== "loading";
 
   async function login() {
     await keycloak?.login();
@@ -41,37 +42,48 @@ const ProfileIcon: React.FC = () => {
   return (
     <div className="relative" ref={menuRef}>
       <div className="hidden md:inline-block align-top p-2 pr-3">
-        {user?.name}
+        {sessionReady ? user?.name : null}
       </div>
       <button
         type="button"
         className="btn btn-ghost btn-circle relative"
         aria-label="Profile"
-        onClick={() => setMenuOpen((v) => !v)}
+        aria-busy={!sessionReady}
+        onClick={() => sessionReady && setMenuOpen((v) => !v)}
+        disabled={!sessionReady}
         data-testid="profile-icon"
       >
-        {user && (
+        {!sessionReady ? (
           <span
-            className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-success ring-2 ring-base-200"
-            title="Logged in"
+            className="loading loading-spinner loading-sm"
+            data-testid="profile-session-loading"
           />
+        ) : (
+          <>
+            {user && (
+              <span
+                className="absolute right-2 top-2 h-2.5 w-2.5 rounded-full bg-success ring-2 ring-base-200"
+                title="Logged in"
+              />
+            )}
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+          </>
         )}
-        <svg
-          className="h-6 w-6"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
-          />
-        </svg>
       </button>
-      {menuOpen && (
+      {menuOpen && sessionReady && (
         <ul className="absolute right-0 mt-2 w-48 menu menu-sm bg-base-200 border border-base-300 rounded-box shadow-lg z-50 p-2">
           {user ? (
             <>

--- a/packages/frontend/src/sharedComponents/keycloakSession/AuthGate.test.tsx
+++ b/packages/frontend/src/sharedComponents/keycloakSession/AuthGate.test.tsx
@@ -1,0 +1,61 @@
+import { SessionContext } from "@sharedComponents/keycloakSession/SessionContext.tsx";
+import { render, screen } from "@testing-library/react";
+import type Keycloak from "keycloak-js";
+import { describe, expect, it } from "vitest";
+import { AuthGate } from "./AuthGate.tsx";
+
+describe("AuthGate", () => {
+  it("shows a spinner while the session is loading", () => {
+    render(
+      <SessionContext value={{ status: "loading" }}>
+        <AuthGate whatToSee="see your projects">
+          <div data-testid="private-content">secret</div>
+        </AuthGate>
+      </SessionContext>
+    );
+
+    expect(screen.getByTestId("loading-spinner")).toBeInTheDocument();
+    expect(screen.queryByTestId("private-content")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/log in to see your projects/i)
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the login message when anonymous", () => {
+    render(
+      <SessionContext
+        value={{
+          status: "anonymous",
+          keycloak: { authenticated: false } as Keycloak,
+        }}
+      >
+        <AuthGate whatToSee="see your projects">
+          <div data-testid="private-content">secret</div>
+        </AuthGate>
+      </SessionContext>
+    );
+
+    expect(
+      screen.getByText(/log in to see your projects/i)
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("private-content")).not.toBeInTheDocument();
+  });
+
+  it("renders children when authenticated", () => {
+    render(
+      <SessionContext
+        value={{
+          status: "authenticated",
+          user: { id: "u1", name: "Ada", email: "ada@example.com" },
+          keycloak: { authenticated: true } as Keycloak,
+        }}
+      >
+        <AuthGate whatToSee="see your projects">
+          <div data-testid="private-content">secret</div>
+        </AuthGate>
+      </SessionContext>
+    );
+
+    expect(screen.getByTestId("private-content")).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/sharedComponents/keycloakSession/AuthGate.tsx
+++ b/packages/frontend/src/sharedComponents/keycloakSession/AuthGate.tsx
@@ -1,0 +1,30 @@
+import { useSession } from "@sharedComponents/keycloakSession/SessionContext.tsx";
+import { PleaseLoginMessage } from "@sharedComponents/PleaseLoginMessage.tsx";
+import Spinner from "@sharedComponents/Spinner.tsx";
+import type React from "react";
+
+/**
+ * Gates private content on session readiness.
+ * - loading: SSO check in progress (spinner, not a login prompt)
+ * - anonymous: show login message
+ * - authenticated: render children
+ */
+export const AuthGate: React.FC<{
+  children: React.ReactNode;
+  /** Phrase for PleaseLoginMessage, e.g. "see your projects" */
+  whatToSee: string;
+  loadingFallback?: React.ReactNode;
+  loginFallback?: React.ReactNode;
+}> = ({ children, whatToSee, loadingFallback, loginFallback }) => {
+  const { status } = useSession();
+
+  if (status === "loading") {
+    return <>{loadingFallback ?? <Spinner />}</>;
+  }
+
+  if (status === "anonymous") {
+    return <>{loginFallback ?? <PleaseLoginMessage whatToSee={whatToSee} />}</>;
+  }
+
+  return <>{children}</>;
+};

--- a/packages/frontend/src/sharedComponents/keycloakSession/SessionContext.tsx
+++ b/packages/frontend/src/sharedComponents/keycloakSession/SessionContext.tsx
@@ -7,10 +7,16 @@ export interface User {
   id: string;
 }
 
+/** Session lifecycle for distinguishing SSO check vs logged-out. */
+export type SessionStatus = "loading" | "authenticated" | "anonymous";
+
 interface SessionContextType {
   user?: User;
   keycloak?: Keycloak;
+  status: SessionStatus;
 }
 
-export const SessionContext = React.createContext<SessionContextType>({});
+export const SessionContext = React.createContext<SessionContextType>({
+  status: "loading",
+});
 export const useSession = () => use(SessionContext);

--- a/packages/frontend/src/sharedComponents/keycloakSession/SessionProvider.tsx
+++ b/packages/frontend/src/sharedComponents/keycloakSession/SessionProvider.tsx
@@ -6,16 +6,29 @@ import {
 } from "@config.ts";
 import {
   SessionContext,
+  type SessionStatus,
   type User,
 } from "@sharedComponents/keycloakSession/SessionContext.tsx";
 import Keycloak from "keycloak-js";
 import { useEffect, useRef, useState } from "react";
+
+function userFromToken(kc: Keycloak): User | undefined {
+  if (!kc.authenticated || !kc.tokenParsed) {
+    return undefined;
+  }
+  return {
+    name: kc.tokenParsed.name || kc.tokenParsed.preferred_username || "User",
+    email: kc.tokenParsed.email || "",
+    id: kc.tokenParsed.sub || "",
+  };
+}
 
 export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [user, setUser] = useState<User | undefined>(undefined);
   const [keycloak, setKeycloak] = useState<Keycloak | undefined>(undefined);
+  const [status, setStatus] = useState<SessionStatus>("loading");
   const initialized = useRef(false);
 
   useEffect(() => {
@@ -33,23 +46,15 @@ export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
       pkceMethod: "S256",
       silentCheckSsoRedirectUri: `${BADGEHUB_FRONTEND_BASE_URL}/silent-check-sso.html`,
     })
-      .then((authenticated) => {
-        if (authenticated && kc.tokenParsed) {
-          setUser({
-            name:
-              kc.tokenParsed.name ||
-              kc.tokenParsed.preferred_username ||
-              "User",
-            email: kc.tokenParsed.email || "",
-            id: kc.tokenParsed.sub || "",
-          });
-        } else {
-          setUser(undefined);
-        }
+      .then(() => {
+        const nextUser = userFromToken(kc);
+        setUser(nextUser);
+        setStatus(nextUser?.id ? "authenticated" : "anonymous");
       })
       .catch((error) => {
         console.error("Keycloak initialization failed:", error);
         setUser(undefined);
+        setStatus("anonymous");
       })
       .finally(() => {
         setKeycloak(kc);
@@ -75,6 +80,8 @@ export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
         }
       } catch (error) {
         console.error("Session expired, redirecting to login", error);
+        setUser(undefined);
+        setStatus("anonymous");
         keycloak.login();
       }
     };
@@ -84,5 +91,9 @@ export const SessionProvider: React.FC<{ children: React.ReactNode }> = ({
     };
   }, [keycloak]);
 
-  return <SessionContext value={{ user, keycloak }}>{children}</SessionContext>;
+  return (
+    <SessionContext value={{ user, keycloak, status }}>
+      {children}
+    </SessionContext>
+  );
 };


### PR DESCRIPTION
Expose session status from Keycloak init, gate private pages with AuthGate, and centralize token refresh so logged-in users no longer see a login prompt on refresh while SSO is still resolving.